### PR TITLE
fix: address first review findings

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -24,7 +24,7 @@ from typing import Optional, List, Dict, Any
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from core.config import setup_logging, get_dialect_api_info
+from core.config import settings, setup_logging, get_dialect_api_info
 from core.transpiler import SQLTranspiler
 from core.parser import SQLParser, SUPPORTED_DIALECTS
 from core.functions_lookup import FunctionEncyclopedia
@@ -149,10 +149,14 @@ app.add_middleware(SecurityHeadersMiddleware)
 
 # Add rate limiting (configurable via settings)
 rate_limiter = RateLimiter(
-    requests_per_window=100,  # settings.rate_limit_requests
-    window_seconds=60  # settings.rate_limit_window
+    requests_per_window=settings.rate_limit_requests,
+    window_seconds=settings.rate_limit_window,
 )
-app.add_middleware(RateLimitMiddleware, limiter=rate_limiter, enabled=True)
+app.add_middleware(
+    RateLimitMiddleware,
+    limiter=rate_limiter,
+    enabled=settings.rate_limit_enabled,
+)
 
 # Initialize services
 transpiler = SQLTranspiler()
@@ -356,13 +360,14 @@ async def convert_sql(request: ConvertRequest):
     }
     ```
     """
-    # Validate dialects
-    if request.source_dialect not in SUPPORTED_DIALECTS:
+    source_dialect = request.source_dialect.lower()
+    target_dialect = request.target_dialect.lower()
+    if source_dialect not in SUPPORTED_DIALECTS:
         raise HTTPException(
             status_code=400, 
             detail=f"Unsupported source dialect: {request.source_dialect}. Supported: {SUPPORTED_DIALECTS}"
         )
-    if request.target_dialect not in SUPPORTED_DIALECTS:
+    if target_dialect not in SUPPORTED_DIALECTS:
         raise HTTPException(
             status_code=400,
             detail=f"Unsupported target dialect: {request.target_dialect}. Supported: {SUPPORTED_DIALECTS}"
@@ -370,8 +375,8 @@ async def convert_sql(request: ConvertRequest):
     
     result = transpiler.transpile(
         request.sql,
-        request.source_dialect,
-        request.target_dialect,
+        source_dialect,
+        target_dialect,
         request.pretty
     )
     return ConvertResponse(
@@ -519,10 +524,26 @@ async def map_type(request: TypeMapRequest):
     
     Returns the equivalent type in the target database with notes.
     """
+    source_dialect = request.source_dialect.lower()
+    target_dialect = request.target_dialect.lower()
+    invalid_dialects = [
+        dialect
+        for dialect in (source_dialect, target_dialect)
+        if dialect not in SUPPORTED_DIALECTS
+    ]
+    if invalid_dialects:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unsupported dialect(s): {', '.join(invalid_dialects)}. "
+                f"Supported: {SUPPORTED_DIALECTS}"
+            ),
+        )
+
     result = type_mapper.suggest_type(
         request.type_name,
-        request.source_dialect,
-        request.target_dialect
+        source_dialect,
+        target_dialect,
     )
     return {
         "success": True,

--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -139,12 +139,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     
     def _get_client_id(self, request: Request) -> str:
         """Extract client identifier from request."""
-        # Try X-Forwarded-For header first (for proxied requests)
-        forwarded = request.headers.get("X-Forwarded-For")
-        if forwarded:
-            return forwarded.split(",")[0].strip()
-        
-        # Fall back to client host
+        # Do not trust X-Forwarded-For here: clients can forge it to bypass
+        # per-client limits. Deployments that sit behind a trusted proxy should
+        # configure the ASGI server's proxy-header support instead.
         if request.client:
             return request.client.host
         

--- a/backend/core/nl2sql.py
+++ b/backend/core/nl2sql.py
@@ -45,7 +45,7 @@ class NL2SQLResult:
 
 
 @dataclass
-class QueryTemplate:
+class LegacyQueryTemplate:
     """Template for pattern-based SQL generation with priority."""
     name: str
     pattern: str  # Regex pattern
@@ -75,7 +75,7 @@ class QueryTemplate:
         return None
 
 
-class Tokenizer:
+class LegacyTokenizer:
     """Smart tokenizer with Chinese and English support.
     
     Performance: All static regex patterns are pre-compiled at class level.
@@ -127,18 +127,18 @@ class Tokenizer:
         compound-word aware splitting for Chinese and word-based for English.
         """
         # Clean punctuation using pre-compiled patterns
-        text = Tokenizer._RE_CN_PUNCT.sub(' ', text)
-        text = Tokenizer._RE_EN_PUNCT.sub(' ', text)
+        text = LegacyTokenizer._RE_CN_PUNCT.sub(' ', text)
+        text = LegacyTokenizer._RE_EN_PUNCT.sub(' ', text)
         
         # Check if text contains Chinese characters
-        has_chinese = bool(Tokenizer._RE_CHINESE_CHARS.search(text))
+        has_chinese = bool(LegacyTokenizer._RE_CHINESE_CHARS.search(text))
         
         if has_chinese and JIEBA_AVAILABLE:
             # Use jieba for Chinese tokenization
             tokens = list(jieba.cut(text, cut_all=False))
         elif has_chinese:
             # Fallback: compound-word aware tokenization
-            tokens = Tokenizer._tokenize_chinese_fallback(text)
+            tokens = LegacyTokenizer._tokenize_chinese_fallback(text)
         else:
             # English: simple word tokenization
             tokens = text.lower().split()
@@ -166,7 +166,7 @@ class Tokenizer:
             
             # Check if this is the start of a known compound word
             matched_compound = None
-            for compound in sorted(Tokenizer.CHINESE_COMPOUNDS, key=len, reverse=True):
+            for compound in sorted(LegacyTokenizer.CHINESE_COMPOUNDS, key=len, reverse=True):
                 if text[i:].startswith(compound):
                     matched_compound = compound
                     break
@@ -174,20 +174,20 @@ class Tokenizer:
             if matched_compound:
                 tokens.append(matched_compound)
                 i += len(matched_compound)
-            elif Tokenizer._RE_CHINESE_CHARS.match(char):
+            elif LegacyTokenizer._RE_CHINESE_CHARS.match(char):
                 # Single Chinese character
                 tokens.append(char)
                 i += 1
-            elif Tokenizer._RE_LETTER.match(char):
+            elif LegacyTokenizer._RE_LETTER.match(char):
                 # English word - collect until non-letter
                 word_start = i
-                while i < text_len and Tokenizer._RE_ALNUM.match(text[i]):
+                while i < text_len and LegacyTokenizer._RE_ALNUM.match(text[i]):
                     i += 1
                 tokens.append(text[word_start:i].lower())
-            elif Tokenizer._RE_DIGIT.match(char):
+            elif LegacyTokenizer._RE_DIGIT.match(char):
                 # Number - collect until non-digit
                 num_start = i
-                while i < text_len and Tokenizer._RE_DIGIT_DOT.match(text[i]):
+                while i < text_len and LegacyTokenizer._RE_DIGIT_DOT.match(text[i]):
                     i += 1
                 tokens.append(text[num_start:i])
             else:
@@ -198,17 +198,17 @@ class Tokenizer:
     @staticmethod
     def extract_numbers(text: str) -> List[str]:
         """Extract all numbers from text."""
-        return Tokenizer._RE_NUMBERS.findall(text)
+        return LegacyTokenizer._RE_NUMBERS.findall(text)
     
     @staticmethod
     def extract_quoted_strings(text: str) -> List[str]:
         """Extract quoted strings from text."""
-        return Tokenizer._RE_QUOTED.findall(text)
+        return LegacyTokenizer._RE_QUOTED.findall(text)
     
     @staticmethod
     def is_chinese(text: str) -> bool:
         """Check if text contains Chinese characters."""
-        return bool(Tokenizer._RE_CHINESE_CHARS.search(text))
+        return bool(LegacyTokenizer._RE_CHINESE_CHARS.search(text))
 
 
 class NL2SQLGenerator:

--- a/backend/core/transpiler.py
+++ b/backend/core/transpiler.py
@@ -118,14 +118,6 @@ class SQLTranspiler:
         logger.info(f"Transpiling SQL: {source} -> {target}, length={len(sql)}")
         logger.debug(f"Input SQL: {sql[:200]}{'...' if len(sql) > 200 else ''}")
         
-        # Check cache first
-        if self._cache_enabled:
-            cache_key = f"{sql}|{source}|{target}|{pretty}"
-            cached = self._cache.get(cache_key)
-            if cached:
-                logger.info("Returning cached result")
-                return TranspileResult(**cached)
-        
         # Security validation
         if self._security_enabled and not skip_security:
             security_result = self._validate_security(sql)
@@ -139,6 +131,15 @@ class SQLTranspiler:
                     error=f"Security check failed: {security_result['reason']}",
                     warnings=security_result["warnings"]
                 )
+
+        # Validate before serving from cache. Otherwise a result cached by an
+        # internal call using skip_security=True could bypass this policy.
+        if self._cache_enabled:
+            cache_key = f"{sql}|{source}|{target}|{pretty}"
+            cached = self._cache.get(cache_key)
+            if cached:
+                logger.info("Returning cached result")
+                return TranspileResult(**cached)
         
         # Validate dialects
         if source not in SUPPORTED_DIALECTS:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -239,6 +239,25 @@ class TestTypesEndpoint:
         data = response.json()
         assert data["success"] is True
 
+    def test_type_mapping_rejects_unsupported_dialect(self):
+        """Invalid dialects must not silently produce an N/A mapping."""
+        response = client.post("/api/types/map", json={
+            "type_name": "VARCHAR",
+            "source_dialect": "invalid_db",
+            "target_dialect": "postgres"
+        })
+        assert response.status_code == 400
+
+    def test_type_mapping_normalizes_dialect_case(self):
+        """Dialect names are case-insensitive at the API boundary."""
+        response = client.post("/api/types/map", json={
+            "type_name": "VARCHAR",
+            "source_dialect": "MYSQL",
+            "target_dialect": "POSTGRES"
+        })
+        assert response.status_code == 200
+        assert response.json()["target_dialect"] == "postgres"
+
 
 class TestNL2SQLEndpoint:
     """Tests for the /api/nl2sql endpoint."""

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -18,6 +18,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from backend.core.cache import TTLCache, CacheEntry, CachedFunction
+from backend.core.config import settings
+from backend.core.transpiler import SQLTranspiler
 
 
 class TestCacheEntry:
@@ -54,6 +56,19 @@ class TestTTLCache:
         cache = TTLCache(max_size=10, ttl=60)
         cache.set("key1", "value1")
         assert cache.get("key1") == "value1"
+
+    def test_security_policy_is_checked_before_a_cached_result(self, monkeypatch):
+        """A result cached by an internal bypass must not bypass normal checks."""
+        monkeypatch.setattr(settings, "security_block_dangerous", True)
+        transpiler = SQLTranspiler()
+        sql = "SELECT * FROM users WHERE id = 1 OR 1=1"
+
+        bypassed = transpiler.transpile(sql, "mysql", "postgres", skip_security=True)
+        assert bypassed.success
+
+        checked = transpiler.transpile(sql, "mysql", "postgres")
+        assert not checked.success
+        assert "Security check failed" in checked.error
     
     def test_get_nonexistent_key(self):
         """Get nonexistent key should return None."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dev = [
 requires = ["setuptools>=75.0.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+include = ["backend*", "frontend*"]
+
 [tool.pytest.ini_options]
 testpaths = ["backend/tests"]
 python_files = ["test_*.py"]


### PR DESCRIPTION
## Summary
- configure setuptools discovery for both `backend` and `frontend`
- use configurable rate-limit settings and stop trusting client-supplied `X-Forwarded-For`
- keep the security check ahead of cache reads
- use the modular NL2SQL tokenizer implementation
- validate and normalize type-mapping dialects

## Validation
- `pytest backend/tests/test_api.py backend/tests/test_cache.py -q` (85 passed)
- `python -m compileall -q backend frontend sdm_local.py`
- editable installation verified with `pip install --no-deps -e .`