### PR TITLE
chore: establish next-stage CI and middleware regression coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main, "feat/**", "fix/**", "chore/**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install project
+        run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+
+      - name: Run full test suite
+        run: pytest
+
+      - name: Compile Python sources
+        run: python -m compileall -q backend frontend sdm_local.py

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -1,0 +1,80 @@
+"""Regression tests for security-sensitive HTTP middleware."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.api.middleware import (
+    RateLimitMiddleware,
+    RateLimiter,
+    SecurityHeadersMiddleware,
+)
+
+
+def make_app(rate_limit: int = 2) -> FastAPI:
+    app = FastAPI()
+    limiter = RateLimiter(requests_per_window=rate_limit, window_seconds=60)
+
+    app.add_middleware(SecurityHeadersMiddleware)
+    app.add_middleware(RateLimitMiddleware, limiter=limiter, enabled=True)
+
+    @app.get("/api/test")
+    async def test_endpoint():
+        return {"success": True}
+
+    @app.get("/health")
+    async def health_endpoint():
+        return {"status": "healthy"}
+
+    return app
+
+
+def test_rate_limit_headers_are_added():
+    client = TestClient(make_app(rate_limit=2))
+
+    response = client.get("/api/test")
+
+    assert response.status_code == 200
+    assert response.headers["X-RateLimit-Limit"] == "2"
+    assert response.headers["X-RateLimit-Remaining"] == "1"
+    assert "X-RateLimit-Reset" in response.headers
+
+
+def test_rate_limit_returns_429_after_limit():
+    client = TestClient(make_app(rate_limit=1))
+
+    first = client.get("/api/test")
+    second = client.get("/api/test")
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.headers["Retry-After"].isdigit()
+    assert second.headers["X-RateLimit-Remaining"] == "0"
+    assert second.json()["error"]["code"] == 429
+
+
+def test_forwarded_for_cannot_change_client_identity():
+    client = TestClient(make_app(rate_limit=1))
+
+    first = client.get("/api/test", headers={"X-Forwarded-For": "203.0.113.10"})
+    second = client.get("/api/test", headers={"X-Forwarded-For": "198.51.100.20"})
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+
+
+def test_health_check_bypasses_rate_limit():
+    client = TestClient(make_app(rate_limit=1))
+
+    assert client.get("/health").status_code == 200
+    assert client.get("/health").status_code == 200
+    assert client.get("/health").status_code == 200
+
+
+def test_security_headers_are_present():
+    client = TestClient(make_app())
+
+    response = client.get("/api/test")
+
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"


### PR DESCRIPTION
## Summary
- add GitHub Actions CI for Python 3.11 and 3.12
- run the full pytest suite instead of only selected test files
- compile backend/frontend sources in CI
- add middleware regression tests for rate-limit headers, 429 behavior, forwarded-for spoofing, health-check bypass, and security headers

## Why
PR #3 fixed several review findings, but the repository had no current CI evidence and limited middleware regression coverage. This PR establishes a repeatable quality gate before further feature development.

## Next hardening items
- unify API version with centralized settings
- make CORS use the same Pydantic settings source as the rest of the app
- validate dialects consistently at API and core-service boundaries
- strengthen NL2SQL and cross-dialect semantic tests