### PR TITLE
fix: preserve composed NL2SQL semantics

### DIFF
--- a/backend/core/nl2sql_components/mappings.py
+++ b/backend/core/nl2sql_components/mappings.py
@@ -117,7 +117,7 @@ TABLE_PATTERNS: Dict[str, str] = {
     "数据": "data", "data": "data", "表": "table", "table": "table",
     "配置": "configs", "config": "configs", "settings": "configs",
     # Categories
-    "分类": "categories", "category": "categories", "categories": "categories",
+    "分类": "categories", "categories": "categories",
     "标签": "tags", "tag": "tags", "tags": "tags",
     # Messages
     "消息": "messages", "message": "messages", "messages": "messages",
@@ -174,6 +174,8 @@ COLUMN_PATTERNS: Dict[str, str] = {
     "产品id": "product_id", "product_id": "product_id",
     "部门id": "dept_id", "dept_id": "dept_id", "department_id": "department_id",
     "父级": "parent_id", "parent_id": "parent_id",
+    # Categorization
+    "分类": "category", "category": "category",
     # Metrics
     "得分": "score", "score": "score", "分数": "score",
     "评分": "rating", "rating": "rating",

--- a/backend/core/nl2sql_components/templates.py
+++ b/backend/core/nl2sql_components/templates.py
@@ -12,6 +12,20 @@ from typing import Optional, Dict, Any, Callable
 logger = logging.getLogger(__name__)
 
 
+# Clause markers that mean a single-purpose template may truncate user intent.
+_COMPOSITION_MARKERS = (
+    "order by", "sort", "排序", "排列",
+    "group by", "grouped by", "分组", "汇总",
+    "limit", "top ", "top\t", "only ", "前",
+)
+
+_TEMPLATE_BLOCKERS = {
+    "condition_query": _COMPOSITION_MARKERS,
+    "aggregate_query": _COMPOSITION_MARKERS,
+    "time_range_query": ("order by", "sort", "排序", "排列", "group by", "分组", "汇总", "limit", "top ", "only ", "前"),
+}
+
+
 @dataclass
 class QueryTemplate:
     """Template for pattern-based SQL generation with priority.
@@ -43,6 +57,15 @@ class QueryTemplate:
         Returns:
             Dictionary of match groups, or None if no match
         """
+        normalized = text.lower()
+        blockers = _TEMPLATE_BLOCKERS.get(self.name, ())
+        if any(marker in normalized for marker in blockers):
+            logger.debug(
+                "Skipping template '%s' because composition markers require enhanced parsing",
+                self.name,
+            )
+            return None
+
         if self._compiled_pattern is None:
             # Fallback to non-compiled if compilation failed
             match = re.search(self.pattern, text, re.IGNORECASE)

--- a/backend/core/nl2sql_components/templates.py
+++ b/backend/core/nl2sql_components/templates.py
@@ -8,11 +8,11 @@ import logging
 from dataclasses import dataclass, field
 from typing import Optional, Dict, Any, Callable
 
-# Configure module logger
 logger = logging.getLogger(__name__)
 
 
-# Clause markers that mean a single-purpose template may truncate user intent.
+# Clause markers that mean a single-purpose or catch-all template may truncate
+# part of the user's intent. Composed queries must flow to enhanced parsing.
 _COMPOSITION_MARKERS = (
     "order by", "sort", "排序", "排列",
     "group by", "grouped by", "分组", "汇总",
@@ -22,24 +22,25 @@ _COMPOSITION_MARKERS = (
 _TEMPLATE_BLOCKERS = {
     "condition_query": _COMPOSITION_MARKERS,
     "aggregate_query": _COMPOSITION_MARKERS,
-    "time_range_query": ("order by", "sort", "排序", "排列", "group by", "分组", "汇总", "limit", "top ", "only ", "前"),
+    "time_range_query": _COMPOSITION_MARKERS,
+    "simple_select": _COMPOSITION_MARKERS,
 }
 
 
 @dataclass
 class QueryTemplate:
     """Template for pattern-based SQL generation with priority.
-    
+
     Templates are matched in priority order (highest first).
     Each template has a regex pattern and a SQL template with placeholders.
     """
     name: str
-    pattern: str  # Regex pattern
-    sql_template: str  # SQL template with placeholders
-    priority: int = 50  # Higher = matched first
-    extractor: Optional[Callable] = None  # Custom extraction function
+    pattern: str
+    sql_template: str
+    priority: int = 50
+    extractor: Optional[Callable] = None
     _compiled_pattern: re.Pattern = field(init=False, repr=False, default=None)
-    
+
     def __post_init__(self):
         """Pre-compile regex pattern for better performance."""
         try:
@@ -47,16 +48,9 @@ class QueryTemplate:
         except re.error as e:
             logger.warning(f"Failed to compile pattern for template {self.name}: {e}")
             self._compiled_pattern = None
-    
+
     def match(self, text: str) -> Optional[Dict[str, Any]]:
-        """Try to match this template against input text.
-        
-        Args:
-            text: Input text to match
-            
-        Returns:
-            Dictionary of match groups, or None if no match
-        """
+        """Try to match this template against input text."""
         normalized = text.lower()
         blockers = _TEMPLATE_BLOCKERS.get(self.name, ())
         if any(marker in normalized for marker in blockers):
@@ -67,67 +61,62 @@ class QueryTemplate:
             return None
 
         if self._compiled_pattern is None:
-            # Fallback to non-compiled if compilation failed
             match = re.search(self.pattern, text, re.IGNORECASE)
         else:
             match = self._compiled_pattern.search(text)
-        
+
         if match:
             return match.groupdict() if match.groupdict() else {"match": match.group(0)}
         return None
 
 
-# Default query templates for NL2SQL
 DEFAULT_QUERY_TEMPLATES = [
-    # High priority: Specific patterns with clear structure
     QueryTemplate(
         name="top_n_query",
         pattern=r"(?:查询|获取|显示|get|show|find)?\s*(?:前|top)\s*(\d+)\s*(?:个|条|名)?\s*(.+?)(?:按|by)?\s*(.+?)?\s*(?:排序|排列|order)?",
         sql_template="SELECT * FROM {table} ORDER BY {order_col} DESC LIMIT {n}",
-        priority=90
+        priority=90,
     ),
     QueryTemplate(
         name="count_by_group",
         pattern=r"(?:统计|计算|count)\s*(?:每个|各个|each)?\s*(.+?)\s*(?:的|的数量|数量|有多少)",
         sql_template="SELECT {group_col}, COUNT(*) AS count FROM {table} GROUP BY {group_col}",
-        priority=85
+        priority=85,
     ),
     QueryTemplate(
         name="time_range_query",
         pattern=r"(?:查询|获取|get|find)?\s*(?:最近|过去|last|past)\s*(\d+)\s*(天|周|月|年|days?|weeks?|months?|years?)\s*(?:的|内的)?\s*(.+)",
         sql_template="SELECT * FROM {table} WHERE {date_col} >= DATE_SUB(CURRENT_DATE, {interval})",
-        priority=85
+        priority=85,
     ),
     QueryTemplate(
         name="aggregate_query",
         pattern=r"(?:计算|求|get)?\s*(.+?)\s*(?:的)?\s*(平均|总和|最大|最小|average|sum|max|min)\s*(.+)",
         sql_template="SELECT {agg_func}({col}) FROM {table}",
-        priority=80
+        priority=80,
     ),
     QueryTemplate(
         name="condition_query",
         pattern=r"(?:查询|获取|find|get)?\s*(.+?)\s*(大于|小于|等于|超过|不等于|greater(?:\s+than)?|less(?:\s+than)?|equal(?:\s+to)?|>|<|=)\s*(\d+\.?\d*)\s*(?:的)?\s*(.+)?",
         sql_template="SELECT * FROM {table} WHERE {col} {op} {value}",
-        priority=75
+        priority=75,
     ),
     QueryTemplate(
         name="join_query",
         pattern=r"(?:查询|获取)?\s*(.+?)\s*(?:和|与|关联|连接|join)\s*(.+?)(?:的|数据)?",
         sql_template="SELECT * FROM {table1} JOIN {table2} ON {join_condition}",
-        priority=70
+        priority=70,
     ),
-    # Medium priority: General patterns
     QueryTemplate(
         name="select_with_columns",
         pattern=r"(?:查询|获取|显示|select|get|show)\s*(.+?)\s*(?:的|from)?\s*(.+?)(?:表|table)?$",
         sql_template="SELECT {columns} FROM {table}",
-        priority=60
+        priority=60,
     ),
-    # Low priority: Catch-all patterns
     QueryTemplate(
         name="simple_select",
         pattern=r"(?:查询|获取|显示|列出|select|get|show|list|find)\s*(?:所有|全部|all)?\s*(.+)",
         sql_template="SELECT * FROM {table}",
-        priority=40
+        priority=40,
     ),
 ]

--- a/backend/tests/test_semantic_regression.py
+++ b/backend/tests/test_semantic_regression.py
@@ -55,6 +55,53 @@ def test_nl2sql_condition_preserves_predicate_semantics():
     assert "100" in predicate_sql
 
 
+def test_nl2sql_composed_condition_preserves_order_and_limit():
+    result = nl2sql.generate(
+        "find products with price greater than 100 order by price desc limit 10",
+        "postgres",
+    )
+
+    assert result.success
+    tree = parse_sql(result.sql, "postgres")
+
+    assert table_names(tree) == {"products"}
+    where = tree.find(exp.Where)
+    assert where is not None
+    predicate_sql = where.this.sql(dialect="postgres").upper()
+    assert "PRICE" in predicate_sql
+    assert ">" in predicate_sql
+    assert "100" in predicate_sql
+
+    order = tree.find(exp.Order)
+    assert order is not None
+    assert "PRICE" in order.sql(dialect="postgres").upper()
+    assert "DESC" in order.sql(dialect="postgres").upper()
+
+    limit = tree.find(exp.Limit)
+    assert limit is not None
+    assert limit.expression is not None
+    assert limit.expression.sql(dialect="postgres") == "10"
+
+
+def test_nl2sql_composed_aggregate_preserves_group_and_order():
+    result = nl2sql.generate(
+        "calculate average price for products grouped by category order by average price desc",
+        "postgres",
+    )
+
+    assert result.success
+    tree = parse_sql(result.sql, "postgres")
+
+    assert table_names(tree) == {"products"}
+    assert tree.find(exp.Avg) is not None
+    group = tree.find(exp.Group)
+    assert group is not None
+    assert "category" in group.sql(dialect="postgres").lower()
+    order = tree.find(exp.Order)
+    assert order is not None
+    assert "DESC" in order.sql(dialect="postgres").upper()
+
+
 def test_nl2sql_top_n_preserves_order_and_limit():
     result = nl2sql.generate("select top 10 customers", "mysql")
 


### PR DESCRIPTION
## Summary
- prevent single-purpose condition, aggregate, and time-range templates from claiming composed queries
- let the enhanced parser handle queries combining multiple clauses
- add regression coverage for condition + order + limit and aggregate + group + order combinations

## Validation
GitHub Actions CI should run the full pytest suite and compileall on Python 3.11 and 3.12.

## Merge policy
Squash merge after CI passes.