### PR TITLE
feat: support Chinese status boolean predicates

### DIFF
--- a/backend/core/nl2sql_components/boolean_conditions.py
+++ b/backend/core/nl2sql_components/boolean_conditions.py
@@ -1,7 +1,7 @@
 """Boolean condition extraction for NL2SQL.
 
-Extract explicit comparison predicates and boolean connectors while preserving
-normal SQL AND-over-OR precedence and user-supplied parentheses.
+Extract explicit comparison and status predicates plus boolean connectors while
+preserving normal SQL AND-over-OR precedence and user-supplied parentheses.
 """
 import re
 from typing import List, Optional, Tuple
@@ -28,8 +28,9 @@ _COMPARISON_PATTERNS = (
 )
 
 _STATUS_PATTERN = re.compile(
-    r"\bstatus\s+(active|enabled|valid|inactive|disabled|invalid|"
-    r"completed|done|pending|paid|unpaid)\b",
+    r"(?:\bstatus\s+|状态\s*(?:为|是|=)\s*)"
+    r"(active|enabled|valid|inactive|disabled|invalid|completed|done|pending|paid|unpaid|"
+    r"有效|无效|已完成|未完成|已支付|未支付)",
     re.IGNORECASE,
 )
 
@@ -37,14 +38,20 @@ _STATUS_CONDITIONS = {
     "active": "status = 'active'",
     "enabled": "status = 'active'",
     "valid": "status = 'active'",
+    "有效": "status = 'active'",
     "inactive": "status = 'inactive'",
     "disabled": "status = 'inactive'",
     "invalid": "status = 'inactive'",
+    "无效": "status = 'inactive'",
     "completed": "status = 'completed'",
     "done": "status = 'completed'",
+    "已完成": "status = 'completed'",
     "pending": "status = 'pending'",
+    "未完成": "status = 'pending'",
     "paid": "status = 'paid'",
+    "已支付": "status = 'paid'",
     "unpaid": "status = 'unpaid'",
+    "未支付": "status = 'unpaid'",
 }
 
 _CN_COLUMNS = {

--- a/backend/tests/test_boolean_status.py
+++ b/backend/tests/test_boolean_status.py
@@ -1,0 +1,49 @@
+"""Regression tests for English and Chinese status predicates in booleans."""
+
+import sqlglot
+from sqlglot import exp
+
+from backend.core.nl2sql import NL2SQLGenerator
+
+
+nl2sql = NL2SQLGenerator()
+
+
+def parse_where(text: str) -> exp.Expression:
+    result = nl2sql.generate(text, "postgres")
+    assert result.success
+    tree = sqlglot.parse_one(result.sql, read="postgres")
+    where = tree.find(exp.Where)
+    assert where is not None
+    return where.this
+
+
+def test_chinese_status_predicate_is_preserved_with_or():
+    boolean = parse_where("查询价格大于100或状态为有效的产品")
+
+    assert isinstance(boolean, exp.Or)
+    assert isinstance(boolean.this, exp.Paren)
+    assert isinstance(boolean.expression, exp.Paren)
+    assert isinstance(boolean.this.this, exp.GT)
+    assert isinstance(boolean.expression.this, exp.EQ)
+    assert boolean.expression.this.this.name.lower() == "status"
+
+
+def test_chinese_status_predicate_is_preserved_with_and():
+    boolean = parse_where("查询数量小于10且状态为无效的产品")
+
+    assert isinstance(boolean, exp.And)
+    assert isinstance(boolean.this, exp.Paren)
+    assert isinstance(boolean.expression, exp.Paren)
+    assert isinstance(boolean.expression.this, exp.EQ)
+    assert boolean.expression.this.this.name.lower() == "status"
+
+
+def test_mixed_english_and_chinese_status_aliases():
+    boolean = parse_where("find products with price greater than 100 and 状态为已完成")
+
+    assert isinstance(boolean, exp.And)
+    assert len(list(boolean.find_all(exp.GT))) == 1
+    status_eq = [node for node in boolean.find_all(exp.EQ) if node.this.name.lower() == "status"]
+    assert len(status_eq) == 1
+    assert status_eq[0].expression.name == "completed"


### PR DESCRIPTION
## Summary
- recognize Chinese status predicates such as `状态为有效`, `状态为无效`, and `状态为已完成`
- preserve them inside mixed AND/OR boolean expressions
- add AST regressions for Chinese and mixed-language status predicates

## Validation
GitHub Actions CI should run the full pytest suite and compileall on Python 3.11 and 3.12.

## Merge policy
Squash merge after CI passes.