### PR TITLE
feat: support additional boolean predicate types

### DIFF
--- a/backend/core/nl2sql_components/boolean_conditions.py
+++ b/backend/core/nl2sql_components/boolean_conditions.py
@@ -1,7 +1,8 @@
 """Boolean condition extraction for NL2SQL.
 
-Extract explicit comparison and status predicates plus boolean connectors while
-preserving normal SQL AND-over-OR precedence and user-supplied parentheses.
+Extract explicit comparison, range, text, null, and status predicates plus boolean
+connectors while preserving normal SQL AND-over-OR precedence and user-supplied
+parentheses.
 """
 import re
 from typing import List, Optional, Tuple
@@ -25,6 +26,42 @@ _COMPARISON_PATTERNS = (
         r"(大于等于|小于等于|不等于|大于|小于|超过|低于|等于)\s*"
         r"([0-9]+(?:\.[0-9]+)?)"
     ),
+)
+
+_RANGE_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_])(price|quantity|amount|age|score|rating|views|clicks)\s+"
+    r"(?:between\s+([0-9]+(?:\.[0-9]+)?)\s+and\s+([0-9]+(?:\.[0-9]+)?)|"
+    r"in\s+(?:the\s+)?range\s+([0-9]+(?:\.[0-9]+)?)\s*(?:to|-)\s*"
+    r"([0-9]+(?:\.[0-9]+)?))",
+    re.IGNORECASE,
+)
+
+_CN_RANGE_PATTERN = re.compile(
+    r"(价格|数量|金额|年龄|得分|评分|浏览量|点击量)\s*"
+    r"(?:在|介于)\s*([0-9]+(?:\.[0-9]+)?)\s*(?:和|到|至|-)+\s*"
+    r"([0-9]+(?:\.[0-9]+)?)\s*(?:之间|范围内|以内)?"
+)
+
+_TEXT_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_])(name|title|description|category|brand)\s+"
+    r"(?:contains|containing|includes|including)\s+"
+    r"(?:the\s+)?[\"']?([^\"']+?)[\"']?(?=\s+(?:and|or)\s+|$)",
+    re.IGNORECASE,
+)
+
+_CN_TEXT_PATTERN = re.compile(
+    r"(名称|名字|标题|描述|分类|品牌)\s*(?:包含|含有|包括)\s*[“\"]?([^”\"]+?)[”\"]?(?=(?:且|并且|或者|或|和)|$)"
+)
+
+_NULL_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_])(name|title|description|category|brand|price|quantity|amount|"
+    r"age|score|rating|views|clicks)\s+(is\s+(?:not\s+)?null|is\s+null)\b",
+    re.IGNORECASE,
+)
+
+_CN_NULL_PATTERN = re.compile(
+    r"(名称|名字|标题|描述|分类|品牌|价格|数量|金额|年龄|得分|评分|浏览量|点击量)\s*"
+    r"(为空|为\s*空|是空|不为空|不为\s*空|非空)"
 )
 
 _STATUS_PATTERN = re.compile(
@@ -63,6 +100,12 @@ _CN_COLUMNS = {
     "评分": "rating",
     "浏览量": "views",
     "点击量": "clicks",
+    "名称": "name",
+    "名字": "name",
+    "标题": "title",
+    "描述": "description",
+    "分类": "category",
+    "品牌": "brand",
 }
 
 _CN_OPERATORS = {
@@ -90,13 +133,44 @@ def _normalize_operator(raw: str) -> str:
     return _CN_OPERATORS.get(raw, normalized.upper())
 
 
+def _text_sql(column: str, value: str) -> str:
+    escaped = value.strip().replace("'", "''")
+    return f"{column} LIKE '%{escaped}%'"
+
+
 def _comparison_matches(text: str) -> List[Tuple[int, int, str]]:
     matches: List[Tuple[int, int, str]] = []
+
     for pattern in _COMPARISON_PATTERNS:
         for match in pattern.finditer(text):
             first, raw_operator, value = match.groups()
             column = _CN_COLUMNS.get(first, first)
             matches.append((match.start(), match.end(), f"{column} {_normalize_operator(raw_operator)} {value}"))
+
+    for pattern in (_RANGE_PATTERN, _CN_RANGE_PATTERN):
+        for match in pattern.finditer(text):
+            groups = match.groups()
+            if len(groups) == 4:
+                first, low1, high1, low2, high2 = groups
+                low, high = low1 or low2, high1 or high2
+            else:
+                first, low, high = groups
+            column = _CN_COLUMNS.get(first, first)
+            matches.append((match.start(), match.end(), f"{column} BETWEEN {low} AND {high}"))
+
+    for pattern in (_TEXT_PATTERN, _CN_TEXT_PATTERN):
+        for match in pattern.finditer(text):
+            first, value = match.groups()
+            column = _CN_COLUMNS.get(first, first)
+            matches.append((match.start(), match.end(), _text_sql(column, value)))
+
+    for pattern in (_NULL_PATTERN, _CN_NULL_PATTERN):
+        for match in pattern.finditer(text):
+            first, raw_predicate = match.groups()
+            column = _CN_COLUMNS.get(first, first)
+            normalized = raw_predicate.replace(" ", "").lower()
+            is_not_null = normalized in {"isnotnull", "不为空", "不为空", "非空", "不为\u7a7a"}
+            matches.append((match.start(), match.end(), f"{column} IS {'NOT ' if is_not_null else ''}NULL"))
 
     for match in _STATUS_PATTERN.finditer(text):
         status = match.group(1).lower()

--- a/backend/core/nl2sql_components/boolean_conditions.py
+++ b/backend/core/nl2sql_components/boolean_conditions.py
@@ -38,7 +38,7 @@ _RANGE_PATTERN = re.compile(
 
 _CN_RANGE_PATTERN = re.compile(
     r"(价格|数量|金额|年龄|得分|评分|浏览量|点击量)\s*"
-    r"(?:在|介于)\s*([0-9]+(?:\.[0-9]+)?)\s*(?:和|到|至|-)+\s*"
+    r"(?:在|介于)\s*([0-9]+(?:\.[0-9]+)?)\s*(?:和|到|至|-)\s*"
     r"([0-9]+(?:\.[0-9]+)?)\s*(?:之间|范围内|以内)?"
 )
 
@@ -55,7 +55,7 @@ _CN_TEXT_PATTERN = re.compile(
 
 _NULL_PATTERN = re.compile(
     r"(?<![A-Za-z0-9_])(name|title|description|category|brand|price|quantity|amount|"
-    r"age|score|rating|views|clicks)\s+(is\s+(?:not\s+)?null|is\s+null)\b",
+    r"age|score|rating|views|clicks)\s+(is\s+(?:not\s+)?null)\b",
     re.IGNORECASE,
 )
 
@@ -150,7 +150,7 @@ def _comparison_matches(text: str) -> List[Tuple[int, int, str]]:
     for pattern in (_RANGE_PATTERN, _CN_RANGE_PATTERN):
         for match in pattern.finditer(text):
             groups = match.groups()
-            if len(groups) == 4:
+            if len(groups) == 5:
                 first, low1, high1, low2, high2 = groups
                 low, high = low1 or low2, high1 or high2
             else:
@@ -169,7 +169,7 @@ def _comparison_matches(text: str) -> List[Tuple[int, int, str]]:
             first, raw_predicate = match.groups()
             column = _CN_COLUMNS.get(first, first)
             normalized = raw_predicate.replace(" ", "").lower()
-            is_not_null = normalized in {"isnotnull", "不为空", "不为空", "非空", "不为\u7a7a"}
+            is_not_null = normalized.startswith(("isnotnull", "不为空", "不为空", "非空", "不为"))
             matches.append((match.start(), match.end(), f"{column} IS {'NOT ' if is_not_null else ''}NULL"))
 
     for match in _STATUS_PATTERN.finditer(text):

--- a/backend/tests/test_boolean_predicate_types.py
+++ b/backend/tests/test_boolean_predicate_types.py
@@ -1,0 +1,58 @@
+"""Regression tests for boolean range, text, and NULL predicates."""
+
+import sqlglot
+from sqlglot import exp
+
+from backend.core.nl2sql import NL2SQLGenerator
+
+
+nl2sql = NL2SQLGenerator()
+
+
+def parse_where(text: str) -> exp.Expression:
+    result = nl2sql.generate(text, "postgres")
+    assert result.success
+    tree = sqlglot.parse_one(result.sql, read="postgres")
+    where = tree.find(exp.Where)
+    assert where is not None
+    return where.this
+
+
+def test_range_predicate_is_preserved_with_or():
+    boolean = parse_where("find products with price between 10 and 20 or status active")
+    assert isinstance(boolean, exp.Or)
+    assert len(list(boolean.find_all(exp.Between))) == 1
+    assert any(
+        node.this.name.lower() == "status" and node.expression.name == "active"
+        for node in boolean.find_all(exp.EQ)
+    )
+
+
+def test_contains_predicate_is_preserved_with_and():
+    boolean = parse_where("find products with name containing phone and price greater than 100")
+    assert isinstance(boolean, exp.And)
+    assert len(list(boolean.find_all(exp.Like))) == 1
+    assert len(list(boolean.find_all(exp.GT))) == 1
+
+
+def test_null_predicate_is_preserved_with_or():
+    boolean = parse_where("find products with description is null or status active")
+    assert isinstance(boolean, exp.Or)
+    assert len(list(boolean.find_all(exp.Is))) == 1
+    assert any(
+        node.this.name.lower() == "status" and node.expression.name == "active"
+        for node in boolean.find_all(exp.EQ)
+    )
+
+
+def test_chinese_range_and_null_predicates_preserve_connectors():
+    boolean = parse_where("查询价格在10到20之间且描述为空或状态为已完成的产品")
+    assert isinstance(boolean, exp.Or)
+    assert isinstance(boolean.this, exp.And)
+    assert len(list(boolean.find_all(exp.Between))) == 1
+    assert len(list(boolean.find_all(exp.Is))) == 1
+    status_eq = [
+        node for node in boolean.find_all(exp.EQ) if node.this.name.lower() == "status"
+    ]
+    assert len(status_eq) == 1
+    assert status_eq[0].expression.name == "completed"


### PR DESCRIPTION
## Summary
- preserve BETWEEN/range predicates inside mixed boolean expressions
- preserve text contains/LIKE predicates inside AND/OR expressions
- preserve IS NULL / IS NOT NULL predicates alongside existing comparisons and status predicates
- add English and Chinese AST regressions

## Validation
GitHub Actions CI runs the full pytest suite and compileall on Python 3.11 and 3.12.

## Merge policy
Squash merge after CI passes.