### PR TITLE
fix: normalize type-map dialect input

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -537,21 +537,8 @@ async def map_type(request: TypeMapRequest):
 
     Returns the equivalent type in the target database with notes.
     """
-    source_dialect = request.source_dialect.lower()
-    target_dialect = request.target_dialect.lower()
-    invalid_dialects = [
-        dialect
-        for dialect in (source_dialect, target_dialect)
-        if dialect not in SUPPORTED_DIALECTS
-    ]
-    if invalid_dialects:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Unsupported dialect(s): {', '.join(invalid_dialects)}. "
-                f"Supported: {SUPPORTED_DIALECTS}"
-            ),
-        )
+    source_dialect = normalize_dialect(request.source_dialect, "source dialect")
+    target_dialect = normalize_dialect(request.target_dialect, "target dialect")
 
     result = type_mapper.suggest_type(
         request.type_name,

--- a/backend/tests/test_type_map_api_regression.py
+++ b/backend/tests/test_type_map_api_regression.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+
+from backend.api.main import app
+
+
+client = TestClient(app)
+
+
+def test_type_mapping_normalizes_dialect_whitespace_and_case() -> None:
+    response = client.post(
+        "/api/types/map",
+        json={
+            "type_name": "VARCHAR",
+            "source_dialect": " MySQL ",
+            "target_dialect": " POSTGRES ",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["target_dialect"] == "postgres"
+
+
+def test_type_mapping_rejects_unsupported_dialect_after_normalization() -> None:
+    response = client.post(
+        "/api/types/map",
+        json={
+            "type_name": "VARCHAR",
+            "source_dialect": " invalid_db ",
+            "target_dialect": " POSTGRES ",
+        },
+    )
+
+    assert response.status_code == 400


### PR DESCRIPTION
Normalize /api/types/map source and target dialects through the shared API boundary validator. Add regression coverage for surrounding whitespace, case-insensitivity, and normalized unsupported dialect rejection.