### PR TITLE
fix: clean up expired rate limiter clients

### DIFF
--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -42,9 +42,16 @@ class RateLimiter:
             requests_per_window: Maximum requests allowed per window
             window_seconds: Window duration in seconds
         """
+        if requests_per_window <= 0:
+            raise ValueError("requests_per_window must be positive")
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be positive")
+
         self._limits: Dict[str, RateLimitEntry] = defaultdict(RateLimitEntry)
         self._requests_per_window = requests_per_window
         self._window_seconds = window_seconds
+        self._cleanup_interval_seconds = max(1.0, float(window_seconds))
+        self._last_cleanup_at = 0.0
         self._lock = Lock()
     
     def is_allowed(self, client_id: str) -> tuple:
@@ -58,6 +65,7 @@ class RateLimiter:
         """
         with self._lock:
             now = time.time()
+            self._prune_expired(now)
             entry = self._limits[client_id]
             
             # Reset window if expired
@@ -73,10 +81,25 @@ class RateLimiter:
             
             entry.requests += 1
             return True, remaining - 1, reset_time
+
+    def _prune_expired(self, now: float) -> None:
+        """Remove clients whose rate-limit window has expired."""
+        if now - self._last_cleanup_at < self._cleanup_interval_seconds:
+            return
+
+        expired_clients = [
+            client_id
+            for client_id, entry in self._limits.items()
+            if now - entry.window_start >= self._window_seconds
+        ]
+        for client_id in expired_clients:
+            del self._limits[client_id]
+        self._last_cleanup_at = now
     
     def get_stats(self) -> Dict:
         """Get rate limiter statistics."""
         with self._lock:
+            self._prune_expired(time.time())
             return {
                 "active_clients": len(self._limits),
                 "requests_per_window": self._requests_per_window,

--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 class RateLimitEntry:
     """Rate limit tracking entry."""
     requests: int = 0
-    window_start: float = field(default_factory=time.time)
+    window_start: float = field(default_factory=lambda: time.time())
 
 
 class RateLimiter:

--- a/backend/tests/test_rate_limiter.py
+++ b/backend/tests/test_rate_limiter.py
@@ -1,0 +1,24 @@
+import pytest
+
+from backend.api.middleware import RateLimiter
+
+
+def test_rate_limiter_rejects_non_positive_configuration() -> None:
+    with pytest.raises(ValueError, match="requests_per_window must be positive"):
+        RateLimiter(requests_per_window=0)
+    with pytest.raises(ValueError, match="window_seconds must be positive"):
+        RateLimiter(window_seconds=0)
+
+
+def test_rate_limiter_prunes_expired_clients(monkeypatch) -> None:
+    current_time = 1000.0
+    monkeypatch.setattr("backend.api.middleware.time.time", lambda: current_time)
+
+    limiter = RateLimiter(requests_per_window=10, window_seconds=60)
+    limiter.is_allowed("stale-client")
+
+    current_time = 1061.0
+    limiter.is_allowed("fresh-client")
+
+    assert "stale-client" not in limiter._limits
+    assert limiter.get_stats()["active_clients"] == 1


### PR DESCRIPTION
Harden the in-memory rate limiter by rejecting non-positive configuration and periodically removing expired client entries. Add regression tests for both behaviors so long-lived processes do not retain stale client state indefinitely.