### PR TITLE
fix: validate background cache cleanup interval

### DIFF
--- a/backend/core/cache.py
+++ b/backend/core/cache.py
@@ -256,6 +256,9 @@ class TTLCache:
         Returns:
             The cleanup thread (already started)
         """
+        if interval <= 0:
+            raise ValueError("interval must be positive")
+
         def cleanup_loop():
             while True:
                 time.sleep(interval)

--- a/backend/tests/test_cache_background_cleanup.py
+++ b/backend/tests/test_cache_background_cleanup.py
@@ -1,0 +1,13 @@
+import pytest
+
+from backend.core.cache import TTLCache
+
+
+def test_background_cleanup_rejects_non_positive_interval() -> None:
+    cache = TTLCache()
+
+    with pytest.raises(ValueError, match="interval must be positive"):
+        cache.start_background_cleanup(interval=0)
+
+    with pytest.raises(ValueError, match="interval must be positive"):
+        cache.start_background_cleanup(interval=-1)


### PR DESCRIPTION
Harden TTLCache background cleanup by rejecting non-positive intervals before starting the daemon thread. Add regression coverage for zero and negative intervals to prevent busy-loop CPU usage from invalid configuration.