### PR TITLE
fix: reject oversized batch transpile requests

### DIFF
--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -40,6 +40,10 @@ def _extract_conditions_with_boolean(self, text, original):
 
 NL2SQLGenerator._extract_conditions_enhanced = _extract_conditions_with_boolean
 
+# Install batch-size validation at the core boundary so oversized requests
+# cannot be silently truncated by the legacy batch implementations.
+from . import batch_validation  # noqa: F401,E402
+
 __all__ = [
     # Configuration
     "setup_logging",

--- a/backend/core/batch_validation.py
+++ b/backend/core/batch_validation.py
@@ -1,0 +1,53 @@
+"""Batch transpile input validation helpers."""
+
+from typing import List
+
+from .config import settings
+from .exceptions import ValidationError
+from .transpiler import SQLTranspiler, TranspileResult
+
+
+_original_batch_transpile = SQLTranspiler.batch_transpile
+_original_batch_transpile_async = SQLTranspiler.batch_transpile_async
+
+
+def _validate_batch_size(statements: List[str]) -> None:
+    """Reject oversized batches instead of silently dropping statements."""
+    if len(statements) > settings.max_batch_size:
+        raise ValidationError(
+            f"Batch contains {len(statements)} statements; maximum is "
+            f"{settings.max_batch_size}",
+            field="statements",
+            value=str(len(statements)),
+        )
+
+
+def _batch_transpile_validated(
+    self: SQLTranspiler,
+    statements: List[str],
+    source: str,
+    target: str,
+    pretty: bool = True,
+) -> List[TranspileResult]:
+    """Validate batch size before delegating to the core implementation."""
+    _validate_batch_size(statements)
+    return _original_batch_transpile(self, statements, source, target, pretty)
+
+
+async def _batch_transpile_async_validated(
+    self: SQLTranspiler,
+    statements: List[str],
+    source: str,
+    target: str,
+    pretty: bool = True,
+    max_concurrent: int = 10,
+) -> List[TranspileResult]:
+    """Validate batch size before delegating to the async implementation."""
+    _validate_batch_size(statements)
+    return await _original_batch_transpile_async(
+        self, statements, source, target, pretty, max_concurrent
+    )
+
+
+SQLTranspiler.batch_transpile = _batch_transpile_validated
+SQLTranspiler.batch_transpile_async = _batch_transpile_async_validated

--- a/backend/tests/test_batch_transpile_validation.py
+++ b/backend/tests/test_batch_transpile_validation.py
@@ -1,0 +1,43 @@
+import asyncio
+
+import pytest
+
+from backend.core.config import settings
+from backend.core.exceptions import ErrorCode, ValidationError
+from backend.core.transpiler import SQLTranspiler
+
+
+def test_batch_transpile_rejects_oversized_input(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "max_batch_size", 2)
+    transpiler = SQLTranspiler()
+
+    with pytest.raises(ValidationError) as exc_info:
+        transpiler.batch_transpile(
+            ["SELECT 1", "SELECT 2", "SELECT 3"],
+            "mysql",
+            "postgres",
+        )
+
+    error = exc_info.value
+    assert error.error_code == ErrorCode.VALIDATION_FAILED
+    assert error.details["field"] == "statements"
+    assert error.details["value"] == "3"
+
+
+def test_batch_transpile_async_rejects_oversized_input(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "max_batch_size", 2)
+    transpiler = SQLTranspiler()
+
+    with pytest.raises(ValidationError) as exc_info:
+        asyncio.run(
+            transpiler.batch_transpile_async(
+                ["SELECT 1", "SELECT 2", "SELECT 3"],
+                "mysql",
+                "postgres",
+            )
+        )
+
+    error = exc_info.value
+    assert error.error_code == ErrorCode.VALIDATION_FAILED
+    assert error.details["field"] == "statements"
+    assert error.details["value"] == "3"


### PR DESCRIPTION
Harden batch transpilation input handling by rejecting requests above the configured maximum instead of silently truncating statements. Apply the same validation to sync and async batch paths, with regression coverage and the existing stable VALIDATION_FAILED taxonomy.