### PR TITLE
fix: reject invalid async batch concurrency

### DIFF
--- a/backend/core/batch_validation.py
+++ b/backend/core/batch_validation.py
@@ -22,6 +22,16 @@ def _validate_batch_size(statements: List[str]) -> None:
         )
 
 
+def _validate_max_concurrent(max_concurrent: int) -> None:
+    """Reject non-positive async concurrency to prevent semaphore deadlocks."""
+    if max_concurrent <= 0:
+        raise ValidationError(
+            f"max_concurrent must be positive; got {max_concurrent}",
+            field="max_concurrent",
+            value=str(max_concurrent),
+        )
+
+
 def _batch_transpile_validated(
     self: SQLTranspiler,
     statements: List[str],
@@ -42,8 +52,9 @@ async def _batch_transpile_async_validated(
     pretty: bool = True,
     max_concurrent: int = 10,
 ) -> List[TranspileResult]:
-    """Validate batch size before delegating to the async implementation."""
+    """Validate batch inputs before delegating to the async implementation."""
     _validate_batch_size(statements)
+    _validate_max_concurrent(max_concurrent)
     return await _original_batch_transpile_async(
         self, statements, source, target, pretty, max_concurrent
     )

--- a/backend/tests/test_batch_transpile_validation.py
+++ b/backend/tests/test_batch_transpile_validation.py
@@ -41,3 +41,23 @@ def test_batch_transpile_async_rejects_oversized_input(monkeypatch) -> None:
     assert error.error_code == ErrorCode.VALIDATION_FAILED
     assert error.details["field"] == "statements"
     assert error.details["value"] == "3"
+
+
+def test_batch_transpile_async_rejects_non_positive_concurrency() -> None:
+    transpiler = SQLTranspiler()
+
+    for max_concurrent in (0, -1):
+        with pytest.raises(ValidationError) as exc_info:
+            asyncio.run(
+                transpiler.batch_transpile_async(
+                    ["SELECT 1"],
+                    "mysql",
+                    "postgres",
+                    max_concurrent=max_concurrent,
+                )
+            )
+
+        error = exc_info.value
+        assert error.error_code == ErrorCode.VALIDATION_FAILED
+        assert error.details["field"] == "max_concurrent"
+        assert error.details["value"] == str(max_concurrent)


### PR DESCRIPTION
Harden async batch transpilation by rejecting non-positive max_concurrent values before creating the semaphore. This prevents max_concurrent=0 from producing a semaphore that can never release work and causing requests to wait indefinitely. Add regression coverage for zero and negative concurrency using the existing VALIDATION_FAILED taxonomy.