### PR TITLE
fix: validate core transpiler input types

### DIFF
--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -44,8 +44,11 @@ NL2SQLGenerator._extract_conditions_enhanced = _extract_conditions_with_boolean
 # cannot be silently truncated by the legacy batch implementations.
 from . import batch_validation  # noqa: F401,E402
 
+# Install core input validation so invalid direct callers receive the same
+# structured validation result as API callers.
+from . import input_validation  # noqa: F401,E402
+
 __all__ = [
-    # Configuration
     "setup_logging",
     "SUPPORTED_DIALECTS",
     "DIALECT_METADATA",
@@ -54,24 +57,16 @@ __all__ = [
     "get_dialect_ui_info",
     "get_dialect_api_info",
     "get_dialect_label",
-    # Parser
     "SQLParser",
     "ParseResult",
-    # Transpiler
     "SQLTranspiler",
     "TranspileResult",
-    # Cache
     "TTLCache",
-    # Post-processor
     "PostProcessor",
-    # Function Encyclopedia
     "FunctionEncyclopedia",
-    # Type Mapper
     "TypeMapper",
-    # NL2SQL
     "NL2SQLGenerator",
     "NL2SQLResult",
-    # Exceptions
     "SDMException",
     "UnsupportedDialectError",
     "TranspileError",

--- a/backend/core/input_validation.py
+++ b/backend/core/input_validation.py
@@ -1,0 +1,60 @@
+"""Core transpiler input validation helpers."""
+
+from typing import Any
+
+from .exceptions import ErrorCode, ValidationError
+from .transpiler import SQLTranspiler, TranspileResult
+
+
+_original_transpile = SQLTranspiler.transpile
+
+
+def _validate_transpile_inputs(sql: Any, source: Any, target: Any) -> None:
+    """Reject invalid core transpile arguments before string operations."""
+    if not isinstance(sql, str):
+        raise ValidationError(
+            "sql must be a string",
+            field="sql",
+            value=type(sql).__name__,
+        )
+    if not isinstance(source, str):
+        raise ValidationError(
+            "source must be a string",
+            field="source",
+            value=type(source).__name__,
+        )
+    if not isinstance(target, str):
+        raise ValidationError(
+            "target must be a string",
+            field="target",
+            value=type(target).__name__,
+        )
+
+
+def _transpile_validated(
+    self: SQLTranspiler,
+    sql: str,
+    source: str,
+    target: str,
+    pretty: bool = True,
+    validate: bool = True,
+    skip_security: bool = False,
+) -> TranspileResult:
+    """Validate inputs before delegating to the transpiler implementation."""
+    try:
+        _validate_transpile_inputs(sql, source, target)
+    except ValidationError as exc:
+        return TranspileResult(
+            success=False,
+            source_sql=sql if isinstance(sql, str) else str(sql),
+            source_dialect=source if isinstance(source, str) else str(source),
+            target_dialect=target if isinstance(target, str) else str(target),
+            error=str(exc),
+            error_code=ErrorCode.VALIDATION_FAILED.value,
+        )
+    return _original_transpile(
+        self, sql, source, target, pretty, validate, skip_security
+    )
+
+
+SQLTranspiler.transpile = _transpile_validated

--- a/backend/tests/test_transpiler_input_validation.py
+++ b/backend/tests/test_transpiler_input_validation.py
@@ -1,0 +1,27 @@
+"""Regression tests for core SQLTranspiler input validation."""
+
+from backend.core.transpiler import SQLTranspiler
+
+
+def test_transpile_rejects_non_string_sql_with_structured_error() -> None:
+    result = SQLTranspiler().transpile(None, "mysql", "postgres")  # type: ignore[arg-type]
+
+    assert result.success is False
+    assert result.error_code == "VALIDATION_FAILED"
+    assert result.error == "sql must be a string"
+
+
+def test_transpile_rejects_non_string_source_with_structured_error() -> None:
+    result = SQLTranspiler().transpile("SELECT 1", None, "postgres")  # type: ignore[arg-type]
+
+    assert result.success is False
+    assert result.error_code == "VALIDATION_FAILED"
+    assert result.error == "source must be a string"
+
+
+def test_transpile_rejects_non_string_target_with_structured_error() -> None:
+    result = SQLTranspiler().transpile("SELECT 1", "mysql", None)  # type: ignore[arg-type]
+
+    assert result.success is False
+    assert result.error_code == "VALIDATION_FAILED"
+    assert result.error == "target must be a string"


### PR DESCRIPTION
Return structured VALIDATION_FAILED results for non-string SQL/source/target inputs instead of leaking AttributeError/TypeError before the transpiler error boundary. Add regression coverage for direct core callers.