### PR TITLE
fix: generate unique request IDs for API logging

### DIFF
--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -6,6 +6,7 @@ Provides rate limiting, logging, and request processing middleware.
 import logging
 import time
 import json
+import uuid
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -181,8 +182,8 @@ class StructuredLoggingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next) -> Response:
         start_time = time.time()
         
-        # Generate request ID
-        request_id = f"{int(start_time * 1000)}"
+        # Generate a unique request ID for log correlation and response tracing.
+        request_id = str(uuid.uuid4())
         
         # Log request
         log_data = {

--- a/backend/tests/test_structured_logging_request_id.py
+++ b/backend/tests/test_structured_logging_request_id.py
@@ -1,39 +1,42 @@
+import asyncio
 import uuid
 
-import pytest
 from fastapi import Response, Request
 
 from backend.api.middleware import StructuredLoggingMiddleware
 
 
-@pytest.mark.asyncio
-async def test_structured_logging_request_ids_are_unique_with_same_timestamp(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr("backend.api.middleware.time.time", lambda: 100.1234)
+def test_structured_logging_request_ids_are_unique_with_same_timestamp() -> None:
+    from backend.api import middleware as middleware_module
 
-    middleware = StructuredLoggingMiddleware(app=None)
+    original_time = middleware_module.time.time
+    middleware_module.time.time = lambda: 100.1234
+    try:
+        middleware = StructuredLoggingMiddleware(app=None)
 
-    scope = {
-        "type": "http",
-        "method": "GET",
-        "path": "/api/test",
-        "raw_path": b"/api/test",
-        "query_string": b"",
-        "headers": [],
-        "client": ("127.0.0.1", 12345),
-        "scheme": "http",
-        "server": ("testserver", 80),
-    }
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/test",
+            "raw_path": b"/api/test",
+            "query_string": b"",
+            "headers": [],
+            "client": ("127.0.0.1", 12345),
+            "scheme": "http",
+            "server": ("testserver", 80),
+        }
 
-    async def call_next(request: Request) -> Response:
-        return Response("ok")
+        async def call_next(request: Request) -> Response:
+            return Response("ok")
 
-    first = await middleware.dispatch(Request(scope), call_next)
-    second = await middleware.dispatch(Request(scope), call_next)
+        async def exercise() -> tuple[str, str]:
+            first = await middleware.dispatch(Request(scope), call_next)
+            second = await middleware.dispatch(Request(scope), call_next)
+            return first.headers["X-Request-ID"], second.headers["X-Request-ID"]
 
-    first_id = first.headers["X-Request-ID"]
-    second_id = second.headers["X-Request-ID"]
+        first_id, second_id = asyncio.run(exercise())
+    finally:
+        middleware_module.time.time = original_time
 
     assert first_id != second_id
     assert uuid.UUID(first_id).version == 4

--- a/backend/tests/test_structured_logging_request_id.py
+++ b/backend/tests/test_structured_logging_request_id.py
@@ -1,0 +1,40 @@
+import uuid
+
+import pytest
+from fastapi import Response, Request
+
+from backend.api.middleware import StructuredLoggingMiddleware
+
+
+@pytest.mark.asyncio
+async def test_structured_logging_request_ids_are_unique_with_same_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("backend.api.middleware.time.time", lambda: 100.1234)
+
+    middleware = StructuredLoggingMiddleware(app=None)
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/test",
+        "raw_path": b"/api/test",
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+        "scheme": "http",
+        "server": ("testserver", 80),
+    }
+
+    async def call_next(request: Request) -> Response:
+        return Response("ok")
+
+    first = await middleware.dispatch(Request(scope), call_next)
+    second = await middleware.dispatch(Request(scope), call_next)
+
+    first_id = first.headers["X-Request-ID"]
+    second_id = second.headers["X-Request-ID"]
+
+    assert first_id != second_id
+    assert uuid.UUID(first_id).version == 4
+    assert uuid.UUID(second_id).version == 4


### PR DESCRIPTION
Replace millisecond timestamp request IDs in StructuredLoggingMiddleware with UUID4 IDs, preventing collisions for concurrent requests processed within the same millisecond. Add regression coverage that fixes the clock and verifies distinct UUID4 values are returned.