### PR TITLE
fix: prioritize negative NULL predicates in NL2SQL

### DIFF
--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -48,6 +48,9 @@ from . import batch_validation  # noqa: F401,E402
 # structured validation result as API callers.
 from . import input_validation  # noqa: F401,E402
 
+# Install the focused NULL-predicate precedence fix after NL2SQLGenerator is loaded.
+from . import nl2sql_null_predicate_fix  # noqa: F401,E402
+
 __all__ = [
     "setup_logging",
     "SUPPORTED_DIALECTS",

--- a/backend/core/nl2sql.py
+++ b/backend/core/nl2sql.py
@@ -288,12 +288,28 @@ class NL2SQLGenerator:
         )
 
         boolean_conditions = extract_boolean_conditions(text_lower)
-        if boolean_conditions:
+        has_explicit_null_predicate = any(
+            keyword in text_lower
+            for keyword in [
+                "为空",
+                "空值",
+                "is null",
+                "null",
+                "empty",
+                "非空",
+                "不为空",
+                "is not null",
+                "not null",
+                "not empty",
+            ]
+        )
+        if boolean_conditions or has_explicit_null_predicate:
             parsed = self._parse_text(text_lower, text)
             parsed.update(analysis)
             operation = self._detect_operation(text_lower)
             table = table_hint or self._extract_table(text_lower)
             columns = column_hints if column_hints else self._extract_columns(text_lower)
+            conditions = self._extract_conditions_enhanced(text_lower, text)
             aggregations = self._extract_aggregations(text_lower)
             group_by = self._extract_group_by(text_lower)
             ordering = self._extract_ordering(text_lower)
@@ -304,7 +320,7 @@ class NL2SQLGenerator:
                 operation,
                 table,
                 columns,
-                boolean_conditions,
+                conditions,
                 aggregations,
                 group_by,
                 ordering,
@@ -462,10 +478,14 @@ class NL2SQLGenerator:
                 col = condition_column or "column"
                 conditions.append(f"{col} LIKE '%{match.group(1)}%'")
 
-        if any(keyword in text for keyword in ["为空", "空值", "is null", "null", "empty"]):
-            conditions.append(f"{condition_column or 'column'} IS NULL")
-        if any(keyword in text for keyword in ["非空", "不为空", "is not null", "not null", "not empty"]):
+        has_negative_null = any(
+            keyword in text
+            for keyword in ["非空", "不为空", "is not null", "not null", "not empty"]
+        )
+        if has_negative_null:
             conditions.append(f"{condition_column or 'column'} IS NOT NULL")
+        elif any(keyword in text for keyword in ["为空", "空值", "is null", "null", "empty"]):
+            conditions.append(f"{condition_column or 'column'} IS NULL")
 
         date_col = "created_at" if "created_at" in text else "date"
         if "今天" in text or "today" in text:

--- a/backend/core/nl2sql_null_predicate_fix.py
+++ b/backend/core/nl2sql_null_predicate_fix.py
@@ -1,0 +1,44 @@
+"""Focused fix for negative NULL predicate extraction in NL2SQL."""
+
+import re
+
+from .nl2sql import NL2SQLGenerator
+
+
+_original_extract_conditions = NL2SQLGenerator._extract_conditions_enhanced
+
+
+def _extract_conditions_with_negative_null_precedence(self, text: str, original: str):
+    """Ensure negative NULL predicates do not also produce IS NULL."""
+    negative_null = re.search(
+        r"(?:\bis\s+not\s+null\b|\bnot\s+null\b|\bnot\s+empty\b|非空|不为空)",
+        text,
+        re.IGNORECASE,
+    )
+    positive_null = re.search(
+        r"(?:\bis\s+null\b|\bnull\b|\bempty\b|为空|空值)",
+        text,
+        re.IGNORECASE,
+    )
+    if not negative_null or (positive_null and positive_null.start() < negative_null.start()):
+        return _original_extract_conditions(self, text, original)
+
+    sanitized_text = re.sub(
+        r"\bis\s+not\s+null\b|\bnot\s+null\b|\bnot\s+empty\b|非空|不为空",
+        "__SDM_NEGATIVE_NULL__",
+        text,
+        flags=re.IGNORECASE,
+    )
+    conditions = _original_extract_conditions(self, sanitized_text, original)
+    conditions = [condition for condition in conditions if not condition.endswith(" IS NULL")]
+
+    condition_column = None
+    for pattern, column in self.COLUMN_PATTERNS.items():
+        if pattern in text:
+            condition_column = column
+            break
+    conditions.append(f"{condition_column or 'column'} IS NOT NULL")
+    return conditions
+
+
+NL2SQLGenerator._extract_conditions_enhanced = _extract_conditions_with_negative_null_precedence

--- a/backend/tests/test_nl2sql_null_predicate_regression.py
+++ b/backend/tests/test_nl2sql_null_predicate_regression.py
@@ -12,18 +12,20 @@ def _where_conditions(text: str):
     tree = sqlglot.parse_one(result.sql, read="postgres")
     where = tree.find(exp.Where)
     assert where is not None
-    return list(where.this.walk()), where.this
+    return where.this
 
 
 def test_is_not_null_does_not_generate_is_null():
-    nodes, where = _where_conditions("find products with description is not null")
-    is_nodes = list(where.find_all(exp.Is))
-    assert len(is_nodes) == 1
-    assert any(isinstance(node, exp.Not) for node in nodes)
+    where = _where_conditions("find products with description is not null")
+    assert len(list(where.find_all(exp.Is))) == 1
+    rendered = where.sql(dialect="postgres").upper()
+    assert " IS NOT NULL" in rendered
+    assert " IS NULL" not in rendered
 
 
 def test_chinese_non_empty_does_not_generate_is_null():
-    nodes, where = _where_conditions("查询描述非空的产品")
-    is_nodes = list(where.find_all(exp.Is))
-    assert len(is_nodes) == 1
-    assert any(isinstance(node, exp.Not) for node in nodes)
+    where = _where_conditions("查询描述非空的产品")
+    assert len(list(where.find_all(exp.Is))) == 1
+    rendered = where.sql(dialect="postgres").upper()
+    assert " IS NOT NULL" in rendered
+    assert " IS NULL" not in rendered

--- a/backend/tests/test_nl2sql_null_predicate_regression.py
+++ b/backend/tests/test_nl2sql_null_predicate_regression.py
@@ -1,0 +1,29 @@
+"""Regression tests for negative NULL predicate precedence in NL2SQL."""
+
+import sqlglot
+from sqlglot import exp
+
+from backend.core.nl2sql import NL2SQLGenerator
+
+
+def _where_conditions(text: str):
+    result = NL2SQLGenerator().generate(text, "postgres")
+    assert result.success
+    tree = sqlglot.parse_one(result.sql, read="postgres")
+    where = tree.find(exp.Where)
+    assert where is not None
+    return list(where.this.walk()), where.this
+
+
+def test_is_not_null_does_not_generate_is_null():
+    nodes, where = _where_conditions("find products with description is not null")
+    is_nodes = list(where.find_all(exp.Is))
+    assert len(is_nodes) == 1
+    assert any(isinstance(node, exp.Not) for node in nodes)
+
+
+def test_chinese_non_empty_does_not_generate_is_null():
+    nodes, where = _where_conditions("查询描述非空的产品")
+    is_nodes = list(where.find_all(exp.Is))
+    assert len(is_nodes) == 1
+    assert any(isinstance(node, exp.Not) for node in nodes)


### PR DESCRIPTION
Fix NL2SQL condition extraction so negative NULL predicates such as `IS NOT NULL` and `非空` do not also produce a contradictory `IS NULL` predicate. Add English and Chinese regression coverage.