### PR TITLE
fix: preserve inclusive comparison semantics in NL2SQL

### DIFF
--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -51,6 +51,9 @@ from . import input_validation  # noqa: F401,E402
 # Install the focused NULL-predicate precedence fix after NL2SQLGenerator is loaded.
 from . import nl2sql_null_predicate_fix  # noqa: F401,E402
 
+# Install the focused comparison precedence fix after the NULL-predicate fix.
+from . import nl2sql_comparison_precedence_fix  # noqa: F401,E402
+
 __all__ = [
     "setup_logging",
     "SUPPORTED_DIALECTS",

--- a/backend/core/nl2sql_comparison_precedence_fix.py
+++ b/backend/core/nl2sql_comparison_precedence_fix.py
@@ -1,0 +1,30 @@
+"""Focused fix for inclusive comparison precedence in legacy NL2SQL parsing."""
+
+import re
+
+from .nl2sql import NL2SQLGenerator
+
+
+_original_extract_conditions = NL2SQLGenerator._extract_conditions_enhanced
+
+
+def _extract_conditions_with_comparison_precedence(self, text: str, original: str):
+    """Preserve >= and <= semantics when inclusive Chinese phrases contain >/< keywords."""
+    conditions = _original_extract_conditions(self, text, original)
+
+    if any(keyword in text for keyword in ["大于等于", "不小于"]):
+        conditions = [
+            re.sub(r"\s>\s(\d+\.?\d*)$", r" >= \1", condition, count=1)
+            for condition in conditions
+        ]
+
+    if any(keyword in text for keyword in ["小于等于", "不大于"]):
+        conditions = [
+            re.sub(r"\s<\s(\d+\.?\d*)$", r" <= \1", condition, count=1)
+            for condition in conditions
+        ]
+
+    return conditions
+
+
+NL2SQLGenerator._extract_conditions_enhanced = _extract_conditions_with_comparison_precedence

--- a/backend/tests/test_nl2sql_comparison_precedence.py
+++ b/backend/tests/test_nl2sql_comparison_precedence.py
@@ -1,0 +1,27 @@
+"""Regression tests for comparison operator precedence in NL2SQL."""
+
+import sqlglot
+from sqlglot import exp
+
+from backend.core.nl2sql import NL2SQLGenerator
+
+
+def _where(text: str) -> exp.Expression:
+    result = NL2SQLGenerator().generate(text, "postgres")
+    assert result.success
+    tree = sqlglot.parse_one(result.sql, read="postgres")
+    where = tree.find(exp.Where)
+    assert where is not None
+    return where.this
+
+
+def test_greater_than_or_equal_is_not_reduced_to_greater_than():
+    where = _where("查询价格大于等于100的产品")
+    assert len(list(where.find_all(exp.GTE))) == 1
+    assert not list(where.find_all(exp.GT))
+
+
+def test_less_than_or_equal_is_not_reduced_to_less_than():
+    where = _where("查询价格小于等于100的产品")
+    assert len(list(where.find_all(exp.LTE))) == 1
+    assert not list(where.find_all(exp.LT))


### PR DESCRIPTION
Fix a precedence bug in NL2SQL condition extraction where Chinese inclusive comparison phrases such as `大于等于` / `不小于` could match the earlier `大于` rule and become `>`; likewise `小于等于` / `不大于` could become `<`.

Add regression coverage for `>=` and `<=` AST semantics and install the focused compatibility fix after the existing NL2SQL condition layers.