### PR TITLE
fix: complete NL2SQL dialect hardening audit

### DIFF
--- a/backend/core/final_hardening.py
+++ b/backend/core/final_hardening.py
@@ -4,6 +4,7 @@ import re
 
 from sqlglot import exp
 
+from .config import SUPPORTED_DIALECTS
 from .nl2sql import NL2SQLGenerator
 from .parser import SQLParser
 from .post_processor import PostProcessor
@@ -86,3 +87,63 @@ def _extract_conditions_with_english_inclusive_comparisons(self, text: str, orig
 
 
 NL2SQLGenerator._extract_conditions_enhanced = _extract_conditions_with_english_inclusive_comparisons
+
+
+_original_apply_dialect_adjustments = NL2SQLGenerator._apply_dialect_adjustments
+
+
+def _apply_dialect_adjustments_safe(self, sql: str, dialect: str):
+    """Apply date rewrites without destructive parenthesis/string replacement."""
+    if dialect == "oracle":
+        adjusted = sql.replace("CURRENT_DATE", "TRUNC(SYSDATE)")
+        adjusted = re.sub(
+            r"DATE_SUB\(TRUNC\(SYSDATE\),\s*(\d+)\)",
+            r"TRUNC(SYSDATE) - \1",
+            adjusted,
+        )
+        return adjusted
+
+    if dialect == "tsql":
+        adjusted = sql.replace("CURRENT_DATE", "CAST(GETDATE() AS DATE)")
+        adjusted = re.sub(
+            r"DATE_SUB\(CAST\(GETDATE\(\) AS DATE\),\s*(\d+)\)",
+            r"DATEADD(DAY, -\1, CAST(GETDATE() AS DATE))",
+            adjusted,
+        )
+        return adjusted
+
+    if dialect == "postgres":
+        return re.sub(
+            r"DATE_SUB\(CURRENT_DATE,\s*(\d+)\)",
+            r"CURRENT_DATE - INTERVAL '\1 days'",
+            sql,
+        )
+
+    return _original_apply_dialect_adjustments(self, sql, dialect)
+
+
+NL2SQLGenerator._apply_dialect_adjustments = _apply_dialect_adjustments_safe
+
+
+_original_generate = NL2SQLGenerator.generate
+
+
+def _generate_normalized(self, text: str, dialect: str = None, table_hint: str = None, column_hints=None):
+    """Normalize direct-call inputs so core and API callers share dialect semantics."""
+    normalized_dialect = (dialect or self.default_dialect).strip().lower()
+    if normalized_dialect not in SUPPORTED_DIALECTS:
+        raise ValueError(
+            f"Unsupported dialect: {dialect}. Supported: {', '.join(SUPPORTED_DIALECTS)}"
+        )
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    return _original_generate(
+        self,
+        text,
+        normalized_dialect,
+        table_hint.strip() if isinstance(table_hint, str) else table_hint,
+        column_hints,
+    )
+
+
+NL2SQLGenerator.generate = _generate_normalized

--- a/backend/tests/test_nl2sql_dialect_adjustment_regressions.py
+++ b/backend/tests/test_nl2sql_dialect_adjustment_regressions.py
@@ -1,0 +1,58 @@
+import pytest
+
+from backend.core.nl2sql import NL2SQLGenerator
+
+
+def test_oracle_date_adjustment_preserves_parentheses():
+    generator = NL2SQLGenerator()
+    sql = "SELECT COALESCE(amount, 0) FROM orders WHERE created_at >= DATE_SUB(CURRENT_DATE, 7)"
+
+    result = generator._apply_dialect_adjustments(sql, "oracle")
+
+    assert "COALESCE(amount, 0)" in result
+    assert "TRUNC(SYSDATE) - 7" in result
+    assert result.count("(") == result.count(")")
+
+
+def test_tsql_date_adjustment_builds_valid_dateadd_expression():
+    generator = NL2SQLGenerator()
+    sql = "SELECT COALESCE(amount, 0) FROM orders WHERE created_at >= DATE_SUB(CURRENT_DATE, 7)"
+
+    result = generator._apply_dialect_adjustments(sql, "tsql")
+
+    assert "COALESCE(amount, 0)" in result
+    assert "DATEADD(DAY, -7, CAST(GETDATE() AS DATE))" in result
+    assert result.count("(") == result.count(")")
+
+
+def test_postgres_date_adjustment_expands_backreference():
+    generator = NL2SQLGenerator()
+    sql = "SELECT * FROM orders WHERE created_at >= DATE_SUB(CURRENT_DATE, 7)"
+
+    result = generator._apply_dialect_adjustments(sql, "postgres")
+
+    assert "CURRENT_DATE - INTERVAL '7 days'" in result
+    assert "\\1 days" not in result
+
+
+def test_nl2sql_normalizes_direct_dialect_input():
+    generator = NL2SQLGenerator()
+
+    result = generator.generate("查询所有用户", " MySQL ")
+
+    assert result.success
+    assert result.dialect == "mysql"
+
+
+def test_nl2sql_rejects_unsupported_direct_dialect():
+    generator = NL2SQLGenerator()
+
+    with pytest.raises(ValueError, match="Unsupported dialect"):
+        generator.generate("查询所有用户", "not-a-dialect")
+
+
+def test_nl2sql_rejects_non_string_text():
+    generator = NL2SQLGenerator()
+
+    with pytest.raises(TypeError, match="text must be a string"):
+        generator.generate(None, "mysql")


### PR DESCRIPTION
本轮整仓审计确认并集中修复 NL2SQL 方言调整层的高置信缺陷：

- Oracle 日期改写不再删除 SQL 中所有右括号，避免生成损坏 AST/SQL。
- T-SQL DATE_SUB 改写为完整、可解析的 DATEADD 表达式。
- PostgreSQL DATE_SUB 替换正确展开捕获组，不再输出字面量 `\\1`。
- NL2SQL 直接调用统一做 dialect strip/lower 与受支持性校验。
- NL2SQL 直接调用拒绝非字符串输入，并保留 table_hint 的边界规范化。
- 增加回归测试覆盖上述行为。

门禁要求：PR CI 全绿后才 squash merge；merge 后继续检查 main push CI。