### PR TITLE
fix: harden production rate limiting and readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ SDM_CACHE_MAX_SIZE=1000
 SDM_RATE_LIMIT_ENABLED=true
 SDM_RATE_LIMIT_REQUESTS=100
 SDM_RATE_LIMIT_WINDOW=60
+# Use memory for a single process; use Redis for shared limits across workers/instances.
+SDM_RATE_LIMIT_BACKEND=memory
+# Required when SDM_RATE_LIMIT_BACKEND=redis, e.g. redis://localhost:6379/0
+SDM_REDIS_URL=""
 
 # --- NL2SQL (Natural Language to SQL) ---
 SDM_NL2SQL_CONFIDENCE_THRESHOLD=0.6
@@ -27,6 +31,8 @@ SDM_NL2SQL_MAX_SUGGESTIONS=5
 # --- SQL Transpiler ---
 SDM_TRANSPILER_PRETTY_DEFAULT=true
 SDM_TRANSPILER_MAX_SQL_LENGTH=100000
+SDM_PARSER_MAX_SQL_LENGTH=100000
+SDM_NL2SQL_MAX_INPUT_LENGTH=8192
 
 # --- Function Encyclopedia ---
 SDM_FUNCTION_SEARCH_LIMIT=50
@@ -34,7 +40,7 @@ SDM_FUNCTION_FUZZY_THRESHOLD=0.4
 
 # --- Security ---
 SDM_SECURITY_CHECK_ENABLED=true
-# Set to true to block dangerous SQL queries (DROP, DELETE without WHERE)
+# Security scanning is enabled by default; blocking is opt-in.
 SDM_SECURITY_BLOCK_DANGEROUS=false
 
 # --- Logging ---

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,13 +1,5 @@
 #!/usr/bin/env python3
-"""FastAPI Backend for SQL Dialect Master.
-
-Enterprise-grade multi-database SQL conversion API with:
-- 12 database dialects support
-- 298 SQL functions encyclopedia
-- 36 data type mappings
-- 40 conversion rules
-- Natural language to SQL generation
-"""
+"""FastAPI Backend for SQL Dialect Master."""
 import logging
 import sys
 import time
@@ -21,7 +13,6 @@ from fastapi.openapi.docs import get_swagger_ui_html, get_redoc_html
 from pydantic import BaseModel, Field, ConfigDict
 from typing import Optional, List, Dict, Any
 
-# Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from core.config import settings, setup_logging, get_dialect_api_info
@@ -31,11 +22,9 @@ from core.functions_lookup import FunctionEncyclopedia
 from core.type_mapping import TypeMapper
 from core.nl2sql import NL2SQLGenerator
 
-# Configure logging for the application
 logger = setup_logging(level=logging.INFO)
 api_logger = logging.getLogger(__name__)
 
-# API metadata
 API_VERSION = settings.api_version
 API_TITLE = settings.api_title
 API_DESCRIPTION = """
@@ -48,8 +37,8 @@ Enterprise-grade multi-database SQL conversion engine.
 | Feature | Description |
 |---------|-------------|
 | 🔄 **SQL Conversion** | Convert SQL between 12 database dialects |
-| 📚 **Function Encyclopedia** | 298 SQL functions with cross-database comparison |
-| 🗂️ **Type Mapping** | 36 data type mappings × 12 databases matrix |
+| 📚 **Function Encyclopedia** | Cross-database SQL function reference |
+| 🗂️ **Type Mapping** | Cross-database data type mapping matrix |
 | 💬 **NL2SQL** | Natural language to SQL (Chinese/English) |
 
 ## 💾 Supported Databases
@@ -77,13 +66,12 @@ print(response.json()["target_sql"])
 
 ## 📖 API Endpoints
 
-- `POST /api/convert` - Convert SQL between 12 database dialects
+- `POST /api/convert` - Convert SQL between database dialects
 - `GET /api/functions` - Search SQL functions
 - `GET /api/types` - Get type mapping matrix
 - `POST /api/nl2sql` - Generate SQL from natural language
 """
 
-# Initialize FastAPI app with enhanced metadata
 app = FastAPI(
     title=API_TITLE,
     description=API_DESCRIPTION,
@@ -95,31 +83,14 @@ app = FastAPI(
         "url": "https://opensource.org/licenses/MIT"
     },
     openapi_tags=[
-        {
-            "name": "conversion",
-            "description": "🔄 SQL dialect conversion operations",
-            "externalDocs": {"description": "Learn more", "url": "https://sqlglot.com/"}
-        },
-        {
-            "name": "functions",
-            "description": "📚 SQL function encyclopedia with 298 functions"
-        },
-        {
-            "name": "types",
-            "description": "🗂️ Data type mapping matrix (36 types × 12 databases)"
-        },
-        {
-            "name": "nl2sql",
-            "description": "💬 Natural language to SQL generation"
-        },
-        {
-            "name": "system",
-            "description": "⚙️ System and health endpoints"
-        }
+        {"name": "conversion", "description": "🔄 SQL dialect conversion operations", "externalDocs": {"description": "Learn more", "url": "https://sqlglot.com/"}},
+        {"name": "functions", "description": "📚 SQL function encyclopedia"},
+        {"name": "types", "description": "🗂️ Data type mapping matrix"},
+        {"name": "nl2sql", "description": "💬 Natural language to SQL generation"},
+        {"name": "system", "description": "⚙️ System and health endpoints"}
     ]
 )
 
-# Import middleware
 from backend.api.middleware import (
     RateLimiter,
     RateLimitMiddleware,
@@ -128,38 +99,28 @@ from backend.api.middleware import (
 )
 from backend.core.exceptions import SDMException, UnsupportedDialectError
 
-# Configure CORS from the centralized Pydantic settings source.
 ALLOWED_ORIGINS = [origin.strip() for origin in settings.allowed_origins.split(",") if origin.strip()]
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ALLOWED_ORIGINS,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "OPTIONS"],  # Restrict to needed methods
+    allow_methods=["GET", "POST", "OPTIONS"],
     allow_headers=["Content-Type", "Authorization", "X-Request-ID"],
 )
-
-# Add security headers
 app.add_middleware(SecurityHeadersMiddleware)
-
-# Add rate limiting (configurable via settings)
 rate_limiter = RateLimiter(
     requests_per_window=settings.rate_limit_requests,
     window_seconds=settings.rate_limit_window,
 )
-app.add_middleware(
-    RateLimitMiddleware,
-    limiter=rate_limiter,
-    enabled=settings.rate_limit_enabled,
-)
+app.add_middleware(RateLimitMiddleware, limiter=rate_limiter, enabled=settings.rate_limit_enabled)
 
-# Initialize services
 transpiler = SQLTranspiler()
 func_encyclopedia = FunctionEncyclopedia()
 type_mapper = TypeMapper()
 nl2sql_generator = NL2SQLGenerator()
 
-# Request timing middleware with logging
+
 @app.middleware("http")
 async def add_process_time_header(request: Request, call_next):
     start_time = time.time()
@@ -167,14 +128,10 @@ async def add_process_time_header(request: Request, call_next):
     process_time = time.time() - start_time
     response.headers["X-Process-Time"] = f"{process_time:.4f}s"
     response.headers["X-API-Version"] = API_VERSION
-
-    # Log request details
-    api_logger.info(
-        f"{request.method} {request.url.path} - {response.status_code} - {process_time:.4f}s"
-    )
+    api_logger.info(f"{request.method} {request.url.path} - {response.status_code} - {process_time:.4f}s")
     return response
 
-# Dialect info for enhanced responses (from centralized config)
+
 DIALECT_INFO = get_dialect_api_info()
 
 
@@ -182,32 +139,19 @@ def normalize_dialect(dialect: str, field_name: str = "dialect") -> str:
     """Normalize and validate a dialect at the API boundary."""
     normalized = dialect.strip().lower()
     if normalized not in SUPPORTED_DIALECTS:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Unsupported {field_name}: {dialect}. Supported: {SUPPORTED_DIALECTS}",
-        )
+        raise HTTPException(status_code=400, detail=f"Unsupported {field_name}: {dialect}. Supported: {SUPPORTED_DIALECTS}")
     return normalized
 
-# === Request/Response Models with Enhanced Documentation ===
 
 class ConvertRequest(BaseModel):
-    """SQL conversion request model."""
     sql: str = Field(..., description="Source SQL statement to convert")
     source_dialect: str = Field(..., description="Source database dialect")
     target_dialect: str = Field(..., description="Target database dialect")
     pretty: bool = Field(True, description="Format output SQL with indentation")
+    model_config = ConfigDict(json_schema_extra={"example": {"sql": "SELECT DATE_FORMAT(created_at, '%Y-%m-%d') FROM orders", "source_dialect": "mysql", "target_dialect": "postgres", "pretty": True}})
 
-    model_config = ConfigDict(json_schema_extra={
-        "example": {
-            "sql": "SELECT DATE_FORMAT(created_at, '%Y-%m-%d') FROM orders",
-            "source_dialect": "mysql",
-            "target_dialect": "postgres",
-            "pretty": True
-        }
-    })
 
 class ConvertResponse(BaseModel):
-    """SQL conversion response model."""
     success: bool = Field(..., description="Whether conversion was successful")
     source_sql: str = Field(..., description="Original SQL statement")
     target_sql: Optional[str] = Field(None, description="Converted SQL statement")
@@ -220,22 +164,15 @@ class ConvertResponse(BaseModel):
     warnings: List[str] = Field(default_factory=list, description="Conversion warnings")
     timestamp: str = Field(default_factory=lambda: datetime.now().isoformat(), description="Response timestamp")
 
+
 class NL2SQLRequest(BaseModel):
-    """Natural language to SQL request model."""
     text: str = Field(..., description="Natural language query (Chinese or English)")
     dialect: str = Field("hive", description="Target SQL dialect")
     table_hint: Optional[str] = Field(None, description="Optional table name hint")
+    model_config = ConfigDict(json_schema_extra={"example": {"text": "统计每个部门的员工数量", "dialect": "mysql", "table_hint": "employees"}})
 
-    model_config = ConfigDict(json_schema_extra={
-        "example": {
-            "text": "统计每个部门的员工数量",
-            "dialect": "mysql",
-            "table_hint": "employees"
-        }
-    })
 
 class NL2SQLResponse(BaseModel):
-    """Natural language to SQL response model."""
     success: bool = Field(..., description="Whether generation was successful")
     input_text: str = Field(..., description="Original natural language input")
     sql: Optional[str] = Field(None, description="Generated SQL statement")
@@ -244,44 +181,28 @@ class NL2SQLResponse(BaseModel):
     confidence: float = Field(0.0, description="Confidence score (0.0-1.0)")
     suggestions: List[str] = Field(default_factory=list, description="Improvement suggestions")
 
+
 class ParseRequest(BaseModel):
-    """SQL parse request model."""
     sql: str = Field(..., description="SQL statement to parse")
     dialect: str = Field("hive", description="SQL dialect")
 
+
 class TypeMapRequest(BaseModel):
-    """Type mapping request model."""
     type_name: str = Field(..., description="Source data type name")
     source_dialect: str = Field(..., description="Source database dialect")
     target_dialect: str = Field(..., description="Target database dialect")
+    model_config = ConfigDict(json_schema_extra={"example": {"type_name": "VARCHAR", "source_dialect": "mysql", "target_dialect": "postgres"}})
 
-    model_config = ConfigDict(json_schema_extra={
-        "example": {
-            "type_name": "VARCHAR",
-            "source_dialect": "mysql",
-            "target_dialect": "postgres"
-        }
-    })
 
 class APIResponse(BaseModel):
-    """Standard API response wrapper."""
     success: bool = Field(..., description="Operation success status")
     data: Optional[Dict[str, Any]] = Field(None, description="Response data")
     error: Optional[str] = Field(None, description="Error message if failed")
     timestamp: str = Field(default_factory=lambda: datetime.now().isoformat())
 
-# === API Endpoints ===
 
 @app.get("/", tags=["system"])
 async def root():
-    """
-    🏠 API Root - Welcome & Service Information
-
-    Returns comprehensive API information including:
-    - Service statistics
-    - Available endpoints
-    - Quick start guide
-    """
     return {
         "name": API_TITLE,
         "version": API_VERSION,
@@ -291,7 +212,7 @@ async def root():
             "functions": {"count": len(func_encyclopedia.functions), "label": "📚 SQL Functions"},
             "types": {"count": len(type_mapper.mappings), "label": "🗂️ Data Types"},
             "dialects": {"count": len(SUPPORTED_DIALECTS), "label": "💾 Databases"},
-            "rules": {"count": 40, "label": "🔧 Conversion Rules"}
+            "rules": {"count": len(transpiler.post_processor.engine.rules), "label": "🔧 Conversion Rules"}
         },
         "endpoints": {
             "🔄 conversion": {"url": "/api/convert", "method": "POST"},
@@ -301,460 +222,193 @@ async def root():
             "🗂️ types": {"url": "/api/types", "method": "GET"},
             "💬 nl2sql": {"url": "/api/nl2sql", "method": "POST"},
             "❤️ health": {"url": "/health", "method": "GET"},
+            "🟢 readiness": {"url": "/ready", "method": "GET"},
             "📖 docs": {"url": "/docs", "method": "GET"}
         },
-        "quick_start": {
-            "example": {
-                "endpoint": "POST /api/convert",
-                "body": {
-                    "sql": "SELECT DATE_FORMAT(created_at, '%Y-%m-%d') FROM orders",
-                    "source_dialect": "mysql",
-                    "target_dialect": "postgres"
-                }
-            }
-        },
+        "quick_start": {"example": {"endpoint": "POST /api/convert", "body": {"sql": "SELECT DATE_FORMAT(created_at, '%Y-%m-%d') FROM orders", "source_dialect": "mysql", "target_dialect": "postgres"}}},
         "timestamp": datetime.now().isoformat()
     }
+
 
 @app.get("/api/dialects", tags=["system"])
 async def get_dialects():
-    """
-    💾 Get Supported SQL Dialects
-
-    Returns all 12 supported database dialects with:
-    - Display name and icon
-    - Category (RDBMS, Big Data, Cloud DW, etc.)
-    - Grouped by category for easy navigation
-    """
-    # Group dialects by category
     by_category = {}
     for dialect, info in DIALECT_INFO.items():
         cat = info["category"]
-        if cat not in by_category:
-            by_category[cat] = []
-        by_category[cat].append({
-            "id": dialect,
-            "name": info["name"],
-            "icon": info["icon"]
-        })
+        by_category.setdefault(cat, []).append({"id": dialect, "name": info["name"], "icon": info["icon"]})
+    return {"success": True, "dialects": SUPPORTED_DIALECTS, "count": len(SUPPORTED_DIALECTS), "details": DIALECT_INFO, "by_category": by_category, "categories": list(by_category.keys())}
 
-    return {
-        "success": True,
-        "dialects": SUPPORTED_DIALECTS,
-        "count": len(SUPPORTED_DIALECTS),
-        "details": DIALECT_INFO,
-        "by_category": by_category,
-        "categories": list(by_category.keys())
-    }
 
 @app.post("/api/convert", response_model=ConvertResponse, tags=["conversion"])
 async def convert_sql(request: ConvertRequest):
-    """
-    Convert SQL from one dialect to another.
-
-    Supports conversion between 12 database dialects with:
-    - Automatic syntax transformation
-    - Function mapping
-    - Type conversion
-    - Compatibility notes
-
-    **Example:**
-    ```json
-    {
-        "sql": "SELECT DATE_FORMAT(created_at, '%Y-%m-%d') FROM orders",
-        "source_dialect": "mysql",
-        "target_dialect": "postgres"
-    }
-    ```
-    """
     source_dialect = request.source_dialect.strip().lower()
     target_dialect = request.target_dialect.strip().lower()
     if source_dialect not in SUPPORTED_DIALECTS:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Unsupported source dialect: {request.source_dialect}. Supported: {SUPPORTED_DIALECTS}"
-        )
+        raise HTTPException(status_code=400, detail=f"Unsupported source dialect: {request.source_dialect}. Supported: {SUPPORTED_DIALECTS}")
     if target_dialect not in SUPPORTED_DIALECTS:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Unsupported target dialect: {request.target_dialect}. Supported: {SUPPORTED_DIALECTS}"
-        )
+        raise HTTPException(status_code=400, detail=f"Unsupported target dialect: {request.target_dialect}. Supported: {SUPPORTED_DIALECTS}")
+    result = transpiler.transpile(request.sql, source_dialect, target_dialect, request.pretty)
+    return ConvertResponse(success=result.success, source_sql=result.source_sql, target_sql=result.target_sql, source_dialect=result.source_dialect, target_dialect=result.target_dialect, error=result.error, error_code=result.error_code, compatibility_notes=result.compatibility_notes, transformations=result.transformations, warnings=result.warnings)
 
-    result = transpiler.transpile(
-        request.sql,
-        source_dialect,
-        target_dialect,
-        request.pretty
-    )
-    return ConvertResponse(
-        success=result.success,
-        source_sql=result.source_sql,
-        target_sql=result.target_sql,
-        source_dialect=result.source_dialect,
-        target_dialect=result.target_dialect,
-        error=result.error,
-        error_code=result.error_code,
-        compatibility_notes=result.compatibility_notes,
-        transformations=result.transformations,
-        warnings=result.warnings
-    )
 
 @app.post("/api/parse", tags=["conversion"])
 async def parse_sql(request: ParseRequest):
-    """
-    Parse SQL and extract elements.
-
-    Extracts tables, columns, functions, and other elements from SQL.
-    """
     dialect = normalize_dialect(request.dialect)
     parser = SQLParser(dialect)
     elements = parser.extract_elements(request.sql)
-    return {
-        "success": True,
-        "dialect": dialect,
-        "elements": elements,
-        "timestamp": datetime.now().isoformat()
-    }
+    return {"success": True, "dialect": dialect, "elements": elements, "timestamp": datetime.now().isoformat()}
+
 
 @app.get("/api/functions", tags=["functions"])
-async def list_functions(
-    search: Optional[str] = Query(None, description="Search term for function name"),
-    category: Optional[str] = Query(None, description="Filter by category (string, date, math, etc.)"),
-    limit: int = Query(50, ge=1, le=500, description="Maximum number of results")
-):
-    """
-    List or search SQL functions.
-
-    **Categories:** string, date, math, aggregate, window, conditional, conversion, json, array, system, geo
-
-    **Examples:**
-    - `/api/functions?search=date` - Search for date functions
-    - `/api/functions?category=string` - List all string functions
-    - `/api/functions?limit=100` - Get first 100 functions
-    """
+async def list_functions(search: Optional[str] = Query(None, description="Search term for function name"), category: Optional[str] = Query(None, description="Filter by category (string, date, math, etc.)"), limit: int = Query(50, ge=1, le=500, description="Maximum number of results")):
     if search:
         functions = func_encyclopedia.search(search, limit)
     elif category:
         functions = func_encyclopedia.list_by_category(category)
     else:
         functions = func_encyclopedia.functions[:limit]
+    return {"success": True, "functions": functions, "count": len(functions), "total": len(func_encyclopedia.functions), "stats": func_encyclopedia.get_stats()}
 
-    return {
-        "success": True,
-        "functions": functions,
-        "count": len(functions),
-        "total": len(func_encyclopedia.functions),
-        "stats": func_encyclopedia.get_stats()
-    }
 
 @app.get("/api/functions/categories", tags=["functions"])
 async def get_function_categories():
-    """
-    Get all function categories with counts.
-
-    Returns list of categories and number of functions in each.
-    """
     categories = func_encyclopedia.get_all_categories()
-    return {
-        "success": True,
-        "categories": categories,
-        "count": len(categories)
-    }
+    return {"success": True, "categories": categories, "count": len(categories)}
+
 
 @app.get("/api/functions/{name}", tags=["functions"])
 async def get_function(name: str):
-    """
-    Get detailed function information.
-
-    Returns function details with syntax for all 12 database dialects.
-    """
     func = func_encyclopedia.get_function(name)
     if not func:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Function '{name}' not found. Try searching with /api/functions?search={name}"
-        )
+        raise HTTPException(status_code=404, detail=f"Function '{name}' not found. Try searching with /api/functions?search={name}")
+    return {"success": True, "function": func, "comparison": func_encyclopedia.compare_dialects(name)}
 
-    comparison = func_encyclopedia.compare_dialects(name)
-    return {
-        "success": True,
-        "function": func,
-        "comparison": comparison
-    }
 
 @app.get("/api/types", tags=["types"])
-async def list_types(
-    source: Optional[str] = Query(None, description="Filter by source dialect"),
-    target: Optional[str] = Query(None, description="Filter by target dialect")
-):
-    """
-    Get type mapping matrix.
-
-    Returns complete 36 types × 12 databases mapping matrix.
-
-    **Type Categories:**
-    - String: STRING, VARCHAR, CHAR, TEXT, etc.
-    - Numeric: BIGINT, INT, DECIMAL, FLOAT, etc.
-    - Date/Time: DATE, TIME, TIMESTAMP, INTERVAL
-    - Complex: ARRAY, MAP, STRUCT, JSON
-    - Special: UUID, INET, GEOMETRY
-    """
+async def list_types(source: Optional[str] = Query(None, description="Filter by source dialect"), target: Optional[str] = Query(None, description="Filter by target dialect")):
     if source is not None:
         source = normalize_dialect(source, "source dialect")
     if target is not None:
         target = normalize_dialect(target, "target dialect")
     matrix = type_mapper.get_matrix(source, target)
-    return {
-        "success": True,
-        "mappings": matrix,
-        "dialects": type_mapper.DIALECTS,
-        "type_count": len(matrix),
-        "precision_warnings": type_mapper.get_precision_warnings()
-    }
+    return {"success": True, "mappings": matrix, "dialects": type_mapper.DIALECTS, "type_count": len(matrix), "precision_warnings": type_mapper.get_precision_warnings()}
+
 
 @app.get("/api/types/{type_name}", tags=["types"])
 async def get_type(type_name: str):
-    """
-    Get type mapping details for a specific type.
-
-    Returns mapping for all 12 database dialects.
-    """
     comparison = type_mapper.compare_types(type_name)
     if "error" in comparison:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Type '{type_name}' not found. Available types: STRING, VARCHAR, INT, BIGINT, DECIMAL, DATE, TIMESTAMP, ARRAY, MAP, JSON, etc."
-        )
-    return {
-        "success": True,
-        **comparison
-    }
+        raise HTTPException(status_code=404, detail=f"Type '{type_name}' not found. Available types: STRING, VARCHAR, INT, BIGINT, DECIMAL, DATE, TIMESTAMP, ARRAY, MAP, JSON, etc.")
+    return {"success": True, **comparison}
+
 
 @app.post("/api/types/map", tags=["types"])
 async def map_type(request: TypeMapRequest):
-    """
-    Map a type from source to target dialect.
-
-    Returns the equivalent type in the target database with notes.
-    """
     source_dialect = normalize_dialect(request.source_dialect, "source dialect")
     target_dialect = normalize_dialect(request.target_dialect, "target dialect")
+    result = type_mapper.suggest_type(request.type_name, source_dialect, target_dialect)
+    return {"success": True, **result, "timestamp": datetime.now().isoformat()}
 
-    result = type_mapper.suggest_type(
-        request.type_name,
-        source_dialect,
-        target_dialect,
-    )
-    return {
-        "success": True,
-        **result,
-        "timestamp": datetime.now().isoformat()
-    }
 
 @app.post("/api/nl2sql", response_model=NL2SQLResponse, tags=["nl2sql"])
 async def generate_sql(request: NL2SQLRequest):
-    """
-    Generate SQL from natural language.
-
-    Supports both Chinese and English input.
-
-    **Examples:**
-    - "查询最近7天的订单" → SELECT * FROM orders WHERE created_at >= DATE_SUB(CURRENT_DATE, 7)
-    - "统计每个部门的员工数量" → SELECT dept, COUNT(*) FROM employees GROUP BY dept
-    - "Get top 10 users by score" → SELECT * FROM users ORDER BY score DESC LIMIT 10
-    """
     dialect = normalize_dialect(request.dialect)
-    result = nl2sql_generator.generate(
-        request.text,
-        dialect,
-        request.table_hint
-    )
-    return NL2SQLResponse(
-        success=result.success,
-        input_text=result.input_text,
-        sql=result.sql,
-        dialect=dialect,
-        explanation=result.explanation,
-        confidence=result.confidence,
-        suggestions=result.suggestions
-    )
+    result = nl2sql_generator.generate(request.text, dialect, request.table_hint)
+    return NL2SQLResponse(success=result.success, input_text=result.input_text, sql=result.sql, dialect=dialect, explanation=result.explanation, confidence=result.confidence, suggestions=result.suggestions)
+
+
+def _run_readiness_checks() -> Dict[str, Dict[str, Any]]:
+    """Run lightweight in-process checks used by readiness probes."""
+    checks: Dict[str, Dict[str, Any]] = {}
+    try:
+        result = transpiler.transpile("SELECT 1 AS test", "mysql", "postgres")
+        checks["transpiler"] = {"status": "ok" if result.success else "error", "test_result": result.success}
+    except Exception as exc:
+        checks["transpiler"] = {"status": "error", "message": str(exc)}
+    try:
+        func = func_encyclopedia.get_function("CONCAT")
+        checks["functions"] = {"status": "ok" if func else "warning", "sample_lookup": "CONCAT" if func else None}
+    except Exception as exc:
+        checks["functions"] = {"status": "error", "message": str(exc)}
+    try:
+        type_result = type_mapper.map_type("VARCHAR", "mysql", "postgres")
+        checks["types"] = {"status": "ok" if type_result.get("success") else "warning", "sample_mapping": type_result.get("target_type")}
+    except Exception as exc:
+        checks["types"] = {"status": "error", "message": str(exc)}
+    try:
+        nl_result = nl2sql_generator.generate("查询所有用户", "mysql")
+        checks["nl2sql"] = {"status": "ok" if nl_result.success else "warning", "confidence": nl_result.confidence}
+    except Exception as exc:
+        checks["nl2sql"] = {"status": "error", "message": str(exc)}
+    return checks
+
 
 @app.get("/health", tags=["system"])
 async def health_check():
-    """
-    ❤️ Health Check Endpoint
-
-    Returns comprehensive service status including:
-    - Overall health status
-    - Individual service status
-    - Resource statistics
-    """
-    services = {
-        "transpiler": {"status": "✅ healthy", "rules": 40, "description": "SQL conversion engine"},
-        "functions": {"status": "✅ healthy", "count": len(func_encyclopedia.functions), "description": "Function encyclopedia"},
-        "types": {"status": "✅ healthy", "count": len(type_mapper.mappings), "description": "Type mapping service"},
-        "nl2sql": {"status": "✅ healthy", "description": "Natural language processor"}
-    }
-
-    all_healthy = all("healthy" in s["status"] for s in services.values())
-
+    """Liveness probe: confirms the application process is serving HTTP."""
     return {
-        "status": "✅ healthy" if all_healthy else "⚠️ degraded",
+        "status": "✅ healthy",
         "version": API_VERSION,
-        "uptime": "Available",
+        "probe": "liveness",
         "timestamp": datetime.now().isoformat(),
-        "services": services,
-        "stats": {
-            "dialects": len(SUPPORTED_DIALECTS),
-            "functions": len(func_encyclopedia.functions),
-            "types": len(type_mapper.mappings),
-            "rules": 40
-        }
     }
+
+
+@app.get("/ready", tags=["system"])
+async def readiness_check():
+    """Readiness probe: validates core services before accepting traffic."""
+    checks = _run_readiness_checks()
+    has_errors = any(check.get("status") == "error" for check in checks.values())
+    all_ok = all(check.get("status") == "ok" for check in checks.values())
+    status = "✅ ready" if all_ok else ("❌ not ready" if has_errors else "⚠️ degraded")
+    payload = {
+        "status": status,
+        "version": API_VERSION,
+        "probe": "readiness",
+        "checks": checks,
+        "timestamp": datetime.now().isoformat(),
+    }
+    return JSONResponse(status_code=200 if all_ok else 503, content=payload)
 
 
 @app.get("/health/deep", tags=["system"])
 async def deep_health_check():
-    """
-    🔍 Deep Health Check Endpoint
+    """Deep health diagnostics; unlike /health, this executes component checks."""
+    checks = _run_readiness_checks()
+    has_errors = any(check.get("status") == "error" for check in checks.values())
+    all_ok = all(check.get("status") == "ok" for check in checks.values())
+    return {"status": "✅ healthy" if all_ok else ("❌ unhealthy" if has_errors else "⚠️ degraded"), "version": API_VERSION, "checks": checks, "timestamp": datetime.now().isoformat()}
 
-    Performs actual validation of all components:
-    - Tests transpiler with sample SQL
-    - Validates function encyclopedia data
-    - Checks type mapping integrity
-    - Verifies NL2SQL generation
-    """
-    checks = {}
-
-    # Test transpiler
-    try:
-        result = transpiler.transpile("SELECT 1 AS test", "mysql", "postgres")
-        checks["transpiler"] = {
-            "status": "✅ ok" if result.success else "❌ error",
-            "test_result": result.success,
-            "cache_stats": transpiler.get_stats().get("cache", {})
-        }
-    except Exception as e:
-        checks["transpiler"] = {"status": "❌ error", "message": str(e)}
-
-    # Test function encyclopedia
-    try:
-        func = func_encyclopedia.get_function("CONCAT")
-        checks["functions"] = {
-            "status": "✅ ok" if func else "⚠️ warning",
-            "total_count": len(func_encyclopedia.functions),
-            "sample_lookup": "CONCAT" if func else None
-        }
-    except Exception as e:
-        checks["functions"] = {"status": "❌ error", "message": str(e)}
-
-    # Test type mapper
-    try:
-        type_result = type_mapper.map_type("VARCHAR", "mysql", "postgres")
-        checks["types"] = {
-            "status": "✅ ok" if type_result.get("success") else "⚠️ warning",
-            "total_count": len(type_mapper.mappings),
-            "sample_mapping": type_result.get("target_type")
-        }
-    except Exception as e:
-        checks["types"] = {"status": "❌ error", "message": str(e)}
-
-    # Test NL2SQL
-    try:
-        nl_result = nl2sql_generator.generate("查询所有用户", "mysql")
-        checks["nl2sql"] = {
-            "status": "✅ ok" if nl_result.success else "⚠️ warning",
-            "confidence": nl_result.confidence,
-            "generated_sql": nl_result.sql[:50] if nl_result.sql else None
-        }
-    except Exception as e:
-        checks["nl2sql"] = {"status": "❌ error", "message": str(e)}
-
-    # Overall status
-    all_ok = all("ok" in c.get("status", "") for c in checks.values())
-    has_errors = any("error" in c.get("status", "") for c in checks.values())
-
-    return {
-        "status": "✅ healthy" if all_ok else ("❌ unhealthy" if has_errors else "⚠️ degraded"),
-        "version": API_VERSION,
-        "checks": checks,
-        "timestamp": datetime.now().isoformat()
-    }
 
 @app.get("/api/stats", tags=["system"])
 async def get_stats():
-    """
-    📊 Get API Statistics
-
-    Returns comprehensive statistics about:
-    - Function encyclopedia
-    - Type mappings
-    - Conversion rules
-    - Supported dialects
-    """
     func_categories = func_encyclopedia.get_all_categories()
-
+    rule_count = len(transpiler.post_processor.engine.rules)
     return {
         "success": True,
         "stats": {
-            "overview": {
-                "total_functions": len(func_encyclopedia.functions),
-                "total_types": len(type_mapper.mappings),
-                "total_dialects": len(SUPPORTED_DIALECTS),
-                "conversion_rules": 40
-            },
-            "functions": {
-                "total": len(func_encyclopedia.functions),
-                "categories": func_categories,
-                "category_count": len(func_categories)
-            },
-            "types": {
-                "total": len(type_mapper.mappings),
-                "dialects": len(type_mapper.DIALECTS),
-                "categories": ["String", "Numeric", "Date/Time", "Complex", "Binary", "Special"]
-            },
-            "dialects": {
-                "list": SUPPORTED_DIALECTS,
-                "details": DIALECT_INFO
-            }
+            "overview": {"total_functions": len(func_encyclopedia.functions), "total_types": len(type_mapper.mappings), "total_dialects": len(SUPPORTED_DIALECTS), "conversion_rules": rule_count},
+            "functions": {"total": len(func_encyclopedia.functions), "categories": func_categories, "category_count": len(func_categories)},
+            "types": {"total": len(type_mapper.mappings), "dialects": len(type_mapper.DIALECTS), "categories": ["String", "Numeric", "Date/Time", "Complex", "Binary", "Special"]},
+            "dialects": {"list": SUPPORTED_DIALECTS, "details": DIALECT_INFO}
         },
         "timestamp": datetime.now().isoformat()
     }
 
-# Custom exception handler for better error responses
+
 @app.exception_handler(HTTPException)
 async def custom_http_exception_handler(request: Request, exc: HTTPException):
-    return JSONResponse(
-        status_code=exc.status_code,
-        content={
-            "success": False,
-            "error": {
-                "code": exc.status_code,
-                "message": exc.detail,
-                "type": "HTTPException"
-            },
-            "timestamp": datetime.now().isoformat()
-        }
-    )
+    return JSONResponse(status_code=exc.status_code, content={"success": False, "error": {"code": exc.status_code, "message": exc.detail, "type": "HTTPException"}, "timestamp": datetime.now().isoformat()})
 
 
 @app.exception_handler(SDMException)
 async def sdm_exception_handler(request: Request, exc: SDMException):
-    """Handle custom SDM exceptions."""
     status_code = 400
     if isinstance(exc, UnsupportedDialectError):
         status_code = 400
+    return JSONResponse(status_code=status_code, content={"success": False, "error": exc.to_dict(), "timestamp": datetime.now().isoformat()})
 
-    return JSONResponse(
-        status_code=status_code,
-        content={
-            "success": False,
-            "error": exc.to_dict(),
-            "timestamp": datetime.now().isoformat()
-        }
-    )
 
-# Run with: uvicorn backend.api.main:app --reload
 if __name__ == "__main__":
     import uvicorn
     print(f"""

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
-"""FastAPI Backend for SQL Dialect Master."""
+"""FastAPI Backend for SQL Dialect Master.
+
+Enterprise-grade multi-database SQL conversion API with:
+- 12 database dialects support
+- 298 SQL functions encyclopedia
+- 36 data type mappings
+- Natural language to SQL generation
+"""
+import asyncio
 import logging
 import sys
 import time
@@ -37,8 +45,8 @@ Enterprise-grade multi-database SQL conversion engine.
 | Feature | Description |
 |---------|-------------|
 | 🔄 **SQL Conversion** | Convert SQL between 12 database dialects |
-| 📚 **Function Encyclopedia** | Cross-database SQL function reference |
-| 🗂️ **Type Mapping** | Cross-database data type mapping matrix |
+| 📚 **Function Encyclopedia** | 298 SQL functions with cross-database comparison |
+| 🗂️ **Type Mapping** | 36 data type mappings × 12 databases matrix |
 | 💬 **NL2SQL** | Natural language to SQL (Chinese/English) |
 
 ## 💾 Supported Databases
@@ -54,8 +62,6 @@ Enterprise-grade multi-database SQL conversion engine.
 
 ```python
 import requests
-
-# Convert SQL
 response = requests.post("http://localhost:8000/api/convert", json={
     "sql": "SELECT DATE_FORMAT(created_at, '%Y-%m-%d') FROM orders",
     "source_dialect": "mysql",
@@ -78,41 +84,41 @@ app = FastAPI(
     version=API_VERSION,
     docs_url="/docs",
     redoc_url="/redoc",
-    license_info={
-        "name": "MIT License",
-        "url": "https://opensource.org/licenses/MIT"
-    },
+    license_info={"name": "MIT License", "url": "https://opensource.org/licenses/MIT"},
     openapi_tags=[
         {"name": "conversion", "description": "🔄 SQL dialect conversion operations", "externalDocs": {"description": "Learn more", "url": "https://sqlglot.com/"}},
         {"name": "functions", "description": "📚 SQL function encyclopedia"},
         {"name": "types", "description": "🗂️ Data type mapping matrix"},
         {"name": "nl2sql", "description": "💬 Natural language to SQL generation"},
-        {"name": "system", "description": "⚙️ System and health endpoints"}
-    ]
+        {"name": "system", "description": "⚙️ System and health endpoints"},
+    ],
 )
 
-from backend.api.middleware import (
-    RateLimiter,
-    RateLimitMiddleware,
-    StructuredLoggingMiddleware,
-    SecurityHeadersMiddleware
-)
+from backend.api.middleware import RateLimiter, RateLimitMiddleware, StructuredLoggingMiddleware, SecurityHeadersMiddleware
 from backend.core.exceptions import SDMException, UnsupportedDialectError
 
 ALLOWED_ORIGINS = [origin.strip() for origin in settings.allowed_origins.split(",") if origin.strip()]
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=ALLOWED_ORIGINS,
-    allow_credentials=True,
-    allow_methods=["GET", "POST", "OPTIONS"],
-    allow_headers=["Content-Type", "Authorization", "X-Request-ID"],
-)
+if "*" in ALLOWED_ORIGINS and settings.allowed_origins.strip() != "*":
+    raise RuntimeError("CORS wildcard must be the only configured origin")
+if "*" in ALLOWED_ORIGINS and True:
+    # Credentials with wildcard origins are forbidden by browser CORS semantics.
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=[],
+        allow_credentials=False,
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["Content-Type", "Authorization", "X-Request-ID"],
+    )
+else:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=ALLOWED_ORIGINS,
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["Content-Type", "Authorization", "X-Request-ID"],
+    )
 app.add_middleware(SecurityHeadersMiddleware)
-rate_limiter = RateLimiter(
-    requests_per_window=settings.rate_limit_requests,
-    window_seconds=settings.rate_limit_window,
-)
+rate_limiter = RateLimiter(requests_per_window=settings.rate_limit_requests, window_seconds=settings.rate_limit_window)
 app.add_middleware(RateLimitMiddleware, limiter=rate_limiter, enabled=settings.rate_limit_enabled)
 
 transpiler = SQLTranspiler()
@@ -136,7 +142,6 @@ DIALECT_INFO = get_dialect_api_info()
 
 
 def normalize_dialect(dialect: str, field_name: str = "dialect") -> str:
-    """Normalize and validate a dialect at the API boundary."""
     normalized = dialect.strip().lower()
     if normalized not in SUPPORTED_DIALECTS:
         raise HTTPException(status_code=400, detail=f"Unsupported {field_name}: {dialect}. Supported: {SUPPORTED_DIALECTS}")
@@ -152,17 +157,17 @@ class ConvertRequest(BaseModel):
 
 
 class ConvertResponse(BaseModel):
-    success: bool = Field(..., description="Whether conversion was successful")
-    source_sql: str = Field(..., description="Original SQL statement")
-    target_sql: Optional[str] = Field(None, description="Converted SQL statement")
-    source_dialect: str = Field(..., description="Source dialect")
-    target_dialect: str = Field(..., description="Target dialect")
-    error: Optional[str] = Field(None, description="Error message if conversion failed")
-    error_code: Optional[str] = Field(None, description="Stable machine-readable error category")
-    compatibility_notes: List[str] = Field(default_factory=list, description="Compatibility notes")
-    transformations: List[str] = Field(default_factory=list, description="Applied transformations")
-    warnings: List[str] = Field(default_factory=list, description="Conversion warnings")
-    timestamp: str = Field(default_factory=lambda: datetime.now().isoformat(), description="Response timestamp")
+    success: bool = Field(...)
+    source_sql: str = Field(...)
+    target_sql: Optional[str] = Field(None)
+    source_dialect: str = Field(...)
+    target_dialect: str = Field(...)
+    error: Optional[str] = Field(None)
+    error_code: Optional[str] = Field(None)
+    compatibility_notes: List[str] = Field(default_factory=list)
+    transformations: List[str] = Field(default_factory=list)
+    warnings: List[str] = Field(default_factory=list)
+    timestamp: str = Field(default_factory=lambda: datetime.now().isoformat())
 
 
 class NL2SQLRequest(BaseModel):
@@ -173,61 +178,38 @@ class NL2SQLRequest(BaseModel):
 
 
 class NL2SQLResponse(BaseModel):
-    success: bool = Field(..., description="Whether generation was successful")
-    input_text: str = Field(..., description="Original natural language input")
-    sql: Optional[str] = Field(None, description="Generated SQL statement")
-    dialect: str = Field(..., description="Target dialect")
-    explanation: str = Field("", description="Explanation of generated SQL")
-    confidence: float = Field(0.0, description="Confidence score (0.0-1.0)")
-    suggestions: List[str] = Field(default_factory=list, description="Improvement suggestions")
+    success: bool = Field(...)
+    input_text: str = Field(...)
+    sql: Optional[str] = Field(None)
+    dialect: str = Field(...)
+    explanation: str = Field("")
+    confidence: float = Field(0.0)
+    suggestions: List[str] = Field(default_factory=list)
 
 
 class ParseRequest(BaseModel):
-    sql: str = Field(..., description="SQL statement to parse")
-    dialect: str = Field("hive", description="SQL dialect")
+    sql: str = Field(...)
+    dialect: str = Field("hive")
 
 
 class TypeMapRequest(BaseModel):
-    type_name: str = Field(..., description="Source data type name")
-    source_dialect: str = Field(..., description="Source database dialect")
-    target_dialect: str = Field(..., description="Target database dialect")
+    type_name: str = Field(...)
+    source_dialect: str = Field(...)
+    target_dialect: str = Field(...)
     model_config = ConfigDict(json_schema_extra={"example": {"type_name": "VARCHAR", "source_dialect": "mysql", "target_dialect": "postgres"}})
 
 
 class APIResponse(BaseModel):
-    success: bool = Field(..., description="Operation success status")
-    data: Optional[Dict[str, Any]] = Field(None, description="Response data")
-    error: Optional[str] = Field(None, description="Error message if failed")
+    success: bool = Field(...)
+    data: Optional[Dict[str, Any]] = Field(None)
+    error: Optional[str] = Field(None)
     timestamp: str = Field(default_factory=lambda: datetime.now().isoformat())
 
 
 @app.get("/", tags=["system"])
 async def root():
-    return {
-        "name": API_TITLE,
-        "version": API_VERSION,
-        "status": "✅ Online",
-        "description": "Enterprise-grade multi-database SQL conversion engine",
-        "stats": {
-            "functions": {"count": len(func_encyclopedia.functions), "label": "📚 SQL Functions"},
-            "types": {"count": len(type_mapper.mappings), "label": "🗂️ Data Types"},
-            "dialects": {"count": len(SUPPORTED_DIALECTS), "label": "💾 Databases"},
-            "rules": {"count": len(transpiler.post_processor.engine.rules), "label": "🔧 Conversion Rules"}
-        },
-        "endpoints": {
-            "🔄 conversion": {"url": "/api/convert", "method": "POST"},
-            "📝 parsing": {"url": "/api/parse", "method": "POST"},
-            "💾 dialects": {"url": "/api/dialects", "method": "GET"},
-            "📚 functions": {"url": "/api/functions", "method": "GET"},
-            "🗂️ types": {"url": "/api/types", "method": "GET"},
-            "💬 nl2sql": {"url": "/api/nl2sql", "method": "POST"},
-            "❤️ health": {"url": "/health", "method": "GET"},
-            "🟢 readiness": {"url": "/ready", "method": "GET"},
-            "📖 docs": {"url": "/docs", "method": "GET"}
-        },
-        "quick_start": {"example": {"endpoint": "POST /api/convert", "body": {"sql": "SELECT DATE_FORMAT(created_at, '%Y-%m-%d') FROM orders", "source_dialect": "mysql", "target_dialect": "postgres"}}},
-        "timestamp": datetime.now().isoformat()
-    }
+    rule_count = len(transpiler.post_processor.engine.rules)
+    return {"name": API_TITLE, "version": API_VERSION, "status": "✅ Online", "description": "Enterprise-grade multi-database SQL conversion engine", "stats": {"functions": {"count": len(func_encyclopedia.functions), "label": "📚 SQL Functions"}, "types": {"count": len(type_mapper.mappings), "label": "🗂️ Data Types"}, "dialects": {"count": len(SUPPORTED_DIALECTS), "label": "💾 Databases"}, "rules": {"count": rule_count, "label": "🔧 Conversion Rules"}}, "endpoints": {"🔄 conversion": {"url": "/api/convert", "method": "POST"}, "📝 parsing": {"url": "/api/parse", "method": "POST"}, "💾 dialects": {"url": "/api/dialects", "method": "GET"}, "📚 functions": {"url": "/api/functions", "method": "GET"}, "🗂️ types": {"url": "/api/types", "method": "GET"}, "💬 nl2sql": {"url": "/api/nl2sql", "method": "POST"}, "❤️ health": {"url": "/health", "method": "GET"}, "🟢 readiness": {"url": "/ready", "method": "GET"}, "📖 docs": {"url": "/docs", "method": "GET"}}, "timestamp": datetime.now().isoformat()}
 
 
 @app.get("/api/dialects", tags=["system"])
@@ -260,7 +242,7 @@ async def parse_sql(request: ParseRequest):
 
 
 @app.get("/api/functions", tags=["functions"])
-async def list_functions(search: Optional[str] = Query(None, description="Search term for function name"), category: Optional[str] = Query(None, description="Filter by category (string, date, math, etc.)"), limit: int = Query(50, ge=1, le=500, description="Maximum number of results")):
+async def list_functions(search: Optional[str] = Query(None, max_length=100), category: Optional[str] = Query(None, max_length=50), limit: int = Query(50, ge=1, le=500)):
     if search:
         functions = func_encyclopedia.search(search, limit)
     elif category:
@@ -285,7 +267,7 @@ async def get_function(name: str):
 
 
 @app.get("/api/types", tags=["types"])
-async def list_types(source: Optional[str] = Query(None, description="Filter by source dialect"), target: Optional[str] = Query(None, description="Filter by target dialect")):
+async def list_types(source: Optional[str] = Query(None, max_length=30), target: Optional[str] = Query(None, max_length=30)):
     if source is not None:
         source = normalize_dialect(source, "source dialect")
     if target is not None:
@@ -298,7 +280,7 @@ async def list_types(source: Optional[str] = Query(None, description="Filter by 
 async def get_type(type_name: str):
     comparison = type_mapper.compare_types(type_name)
     if "error" in comparison:
-        raise HTTPException(status_code=404, detail=f"Type '{type_name}' not found. Available types: STRING, VARCHAR, INT, BIGINT, DECIMAL, DATE, TIMESTAMP, ARRAY, MAP, JSON, etc.")
+        raise HTTPException(status_code=404, detail=f"Type '{type_name}' not found.")
     return {"success": True, **comparison}
 
 
@@ -318,65 +300,60 @@ async def generate_sql(request: NL2SQLRequest):
 
 
 def _run_readiness_checks() -> Dict[str, Dict[str, Any]]:
-    """Run lightweight in-process checks used by readiness probes."""
-    checks: Dict[str, Dict[str, Any]] = {}
+    checks = {}
     try:
         result = transpiler.transpile("SELECT 1 AS test", "mysql", "postgres")
-        checks["transpiler"] = {"status": "ok" if result.success else "error", "test_result": result.success}
+        checks["transpiler"] = {"status": "✅ ok" if result.success else "❌ error", "test_result": result.success, "cache_stats": transpiler.get_stats().get("cache", {})}
     except Exception as exc:
-        checks["transpiler"] = {"status": "error", "message": str(exc)}
+        checks["transpiler"] = {"status": "❌ error", "message": str(exc)}
     try:
         func = func_encyclopedia.get_function("CONCAT")
-        checks["functions"] = {"status": "ok" if func else "warning", "sample_lookup": "CONCAT" if func else None}
+        checks["functions"] = {"status": "✅ ok" if func else "⚠️ warning", "total_count": len(func_encyclopedia.functions), "sample_lookup": "CONCAT" if func else None}
     except Exception as exc:
-        checks["functions"] = {"status": "error", "message": str(exc)}
+        checks["functions"] = {"status": "❌ error", "message": str(exc)}
     try:
         type_result = type_mapper.map_type("VARCHAR", "mysql", "postgres")
-        checks["types"] = {"status": "ok" if type_result.get("success") else "warning", "sample_mapping": type_result.get("target_type")}
+        checks["types"] = {"status": "✅ ok" if type_result.get("success") else "⚠️ warning", "total_count": len(type_mapper.mappings), "sample_mapping": type_result.get("target_type")}
     except Exception as exc:
-        checks["types"] = {"status": "error", "message": str(exc)}
+        checks["types"] = {"status": "❌ error", "message": str(exc)}
     try:
         nl_result = nl2sql_generator.generate("查询所有用户", "mysql")
-        checks["nl2sql"] = {"status": "ok" if nl_result.success else "warning", "confidence": nl_result.confidence}
+        checks["nl2sql"] = {"status": "✅ ok" if nl_result.success else "⚠️ warning", "confidence": nl_result.confidence, "generated_sql": nl_result.sql[:50] if nl_result.sql else None}
     except Exception as exc:
-        checks["nl2sql"] = {"status": "error", "message": str(exc)}
+        checks["nl2sql"] = {"status": "❌ error", "message": str(exc)}
     return checks
 
 
 @app.get("/health", tags=["system"])
 async def health_check():
-    """Liveness probe: confirms the application process is serving HTTP."""
-    return {
-        "status": "✅ healthy",
-        "version": API_VERSION,
-        "probe": "liveness",
-        "timestamp": datetime.now().isoformat(),
+    rule_count = len(transpiler.post_processor.engine.rules)
+    services = {
+        "transpiler": {"status": "✅ healthy", "rules": rule_count, "description": "SQL conversion engine"},
+        "functions": {"status": "✅ healthy", "count": len(func_encyclopedia.functions), "description": "Function encyclopedia"},
+        "types": {"status": "✅ healthy", "count": len(type_mapper.mappings), "description": "Type mapping service"},
+        "nl2sql": {"status": "✅ healthy", "description": "Natural language processor"},
     }
+    return {"status": "✅ healthy", "version": API_VERSION, "probe": "liveness", "uptime": "Available", "timestamp": datetime.now().isoformat(), "services": services, "stats": {"dialects": len(SUPPORTED_DIALECTS), "functions": len(func_encyclopedia.functions), "types": len(type_mapper.mappings), "rules": rule_count}}
+
+
+async def _readiness_checks_async():
+    return await asyncio.to_thread(_run_readiness_checks)
 
 
 @app.get("/ready", tags=["system"])
 async def readiness_check():
-    """Readiness probe: validates core services before accepting traffic."""
-    checks = _run_readiness_checks()
-    has_errors = any(check.get("status") == "error" for check in checks.values())
-    all_ok = all(check.get("status") == "ok" for check in checks.values())
-    status = "✅ ready" if all_ok else ("❌ not ready" if has_errors else "⚠️ degraded")
-    payload = {
-        "status": status,
-        "version": API_VERSION,
-        "probe": "readiness",
-        "checks": checks,
-        "timestamp": datetime.now().isoformat(),
-    }
+    checks = await _readiness_checks_async()
+    has_errors = any("error" in check.get("status", "").lower() for check in checks.values())
+    all_ok = all("ok" in check.get("status", "").lower() for check in checks.values())
+    payload = {"status": "✅ ready" if all_ok else ("❌ not ready" if has_errors else "⚠️ degraded"), "version": API_VERSION, "probe": "readiness", "checks": checks, "timestamp": datetime.now().isoformat()}
     return JSONResponse(status_code=200 if all_ok else 503, content=payload)
 
 
 @app.get("/health/deep", tags=["system"])
 async def deep_health_check():
-    """Deep health diagnostics; unlike /health, this executes component checks."""
-    checks = _run_readiness_checks()
-    has_errors = any(check.get("status") == "error" for check in checks.values())
-    all_ok = all(check.get("status") == "ok" for check in checks.values())
+    checks = await _readiness_checks_async()
+    has_errors = any("error" in check.get("status", "").lower() for check in checks.values())
+    all_ok = all("ok" in check.get("status", "").lower() for check in checks.values())
     return {"status": "✅ healthy" if all_ok else ("❌ unhealthy" if has_errors else "⚠️ degraded"), "version": API_VERSION, "checks": checks, "timestamp": datetime.now().isoformat()}
 
 
@@ -384,16 +361,7 @@ async def deep_health_check():
 async def get_stats():
     func_categories = func_encyclopedia.get_all_categories()
     rule_count = len(transpiler.post_processor.engine.rules)
-    return {
-        "success": True,
-        "stats": {
-            "overview": {"total_functions": len(func_encyclopedia.functions), "total_types": len(type_mapper.mappings), "total_dialects": len(SUPPORTED_DIALECTS), "conversion_rules": rule_count},
-            "functions": {"total": len(func_encyclopedia.functions), "categories": func_categories, "category_count": len(func_categories)},
-            "types": {"total": len(type_mapper.mappings), "dialects": len(type_mapper.DIALECTS), "categories": ["String", "Numeric", "Date/Time", "Complex", "Binary", "Special"]},
-            "dialects": {"list": SUPPORTED_DIALECTS, "details": DIALECT_INFO}
-        },
-        "timestamp": datetime.now().isoformat()
-    }
+    return {"success": True, "stats": {"overview": {"total_functions": len(func_encyclopedia.functions), "total_types": len(type_mapper.mappings), "total_dialects": len(SUPPORTED_DIALECTS), "conversion_rules": rule_count}, "functions": {"total": len(func_encyclopedia.functions), "categories": func_categories, "category_count": len(func_categories)}, "types": {"total": len(type_mapper.mappings), "dialects": len(type_mapper.DIALECTS), "categories": ["String", "Numeric", "Date/Time", "Complex", "Binary", "Special"]}, "dialects": {"list": SUPPORTED_DIALECTS, "details": DIALECT_INFO}}, "timestamp": datetime.now().isoformat()}
 
 
 @app.exception_handler(HTTPException)
@@ -403,22 +371,9 @@ async def custom_http_exception_handler(request: Request, exc: HTTPException):
 
 @app.exception_handler(SDMException)
 async def sdm_exception_handler(request: Request, exc: SDMException):
-    status_code = 400
-    if isinstance(exc, UnsupportedDialectError):
-        status_code = 400
-    return JSONResponse(status_code=status_code, content={"success": False, "error": exc.to_dict(), "timestamp": datetime.now().isoformat()})
+    return JSONResponse(status_code=400, content={"success": False, "error": exc.to_dict(), "timestamp": datetime.now().isoformat()})
 
 
 if __name__ == "__main__":
     import uvicorn
-    print(f"""
-    ╔══════════════════════════════════════════════════════════╗
-    ║  🔄 SQL Dialect Master API v{API_VERSION}                      ║
-    ║  ──────────────────────────────────────────────────────  ║
-    ║  📚 Functions: {len(func_encyclopedia.functions):>3}  │  🗂️ Types: {len(type_mapper.mappings):>2}  │  💾 DBs: {len(SUPPORTED_DIALECTS):>2}   ║
-    ║  ──────────────────────────────────────────────────────  ║
-    ║  📖 Docs: http://localhost:8000/docs                     ║
-    ║  ❤️ Health: http://localhost:8000/health                 ║
-    ╚══════════════════════════════════════════════════════════╝
-    """)
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -42,22 +42,19 @@ class RateLimiter:
 
     @property
     def _limits(self):
-        """Read-only compatibility view for the legacy in-memory implementation."""
         return getattr(self._store, "_entries", {})
 
     def is_allowed(self, client_id: str) -> tuple:
-        """Check and consume one request from the configured store."""
         return self._store.check(client_id, self._requests_per_window, self._window_seconds)
 
     def get_stats(self) -> Dict:
-        """Get rate limiter configuration and store metadata."""
         stats = self._store.stats()
         stats.update({"requests_per_window": self._requests_per_window, "window_seconds": self._window_seconds})
         return stats
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
-    """Rate limiting middleware with an early request-body size guard."""
+    """Rate limiting middleware with a bounded request-body guard."""
 
     def __init__(self, app, limiter: RateLimiter = None, enabled: bool = True, max_body_bytes: int = DEFAULT_MAX_REQUEST_BODY_BYTES):
         super().__init__(app)
@@ -67,16 +64,32 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self.enabled = enabled
         self.max_body_bytes = max_body_bytes
 
-    async def dispatch(self, request: Request, call_next) -> Response:
-        if request.method not in {"GET", "HEAD"}:
-            content_length = request.headers.get("content-length")
-            if content_length:
-                try:
-                    declared_length = int(content_length)
-                except ValueError:
-                    return JSONResponse(status_code=400, content={"success": False, "error": {"code": 400, "message": "Invalid Content-Length"}, "timestamp": datetime.now().isoformat()})
-                if declared_length > self.max_body_bytes:
+    async def _read_bounded_body(self, request: Request) -> Response | None:
+        """Consume and cache request bodies without trusting Content-Length."""
+        if request.method in {"GET", "HEAD"}:
+            return None
+        content_length = request.headers.get("content-length")
+        if content_length:
+            try:
+                if int(content_length) > self.max_body_bytes:
                     return JSONResponse(status_code=413, content={"success": False, "error": {"code": 413, "message": "Request body exceeds the maximum allowed size", "max_bytes": self.max_body_bytes}, "timestamp": datetime.now().isoformat()})
+            except ValueError:
+                return JSONResponse(status_code=400, content={"success": False, "error": {"code": 400, "message": "Invalid Content-Length"}, "timestamp": datetime.now().isoformat()})
+
+        total = 0
+        chunks = []
+        async for chunk in request.stream():
+            total += len(chunk)
+            if total > self.max_body_bytes:
+                return JSONResponse(status_code=413, content={"success": False, "error": {"code": 413, "message": "Request body exceeds the maximum allowed size", "max_bytes": self.max_body_bytes}, "timestamp": datetime.now().isoformat()})
+            chunks.append(chunk)
+        request._body = b"".join(chunks)
+        return None
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        body_error = await self._read_bounded_body(request)
+        if body_error is not None:
+            return body_error
 
         if not self.enabled:
             return await call_next(request)
@@ -87,11 +100,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         is_allowed, remaining, reset_time = self.limiter.is_allowed(client_id)
         if not is_allowed:
             logger.warning(f"Rate limit exceeded for client: {client_id}")
-            return JSONResponse(
-                status_code=429,
-                content={"success": False, "error": {"code": 429, "message": "Rate limit exceeded", "retry_after": reset_time}, "timestamp": datetime.now().isoformat()},
-                headers={"X-RateLimit-Limit": str(self.limiter._requests_per_window), "X-RateLimit-Remaining": "0", "X-RateLimit-Reset": str(reset_time), "Retry-After": str(reset_time)},
-            )
+            return JSONResponse(status_code=429, content={"success": False, "error": {"code": 429, "message": "Rate limit exceeded", "retry_after": reset_time}, "timestamp": datetime.now().isoformat()}, headers={"X-RateLimit-Limit": str(self.limiter._requests_per_window), "X-RateLimit-Remaining": "0", "X-RateLimit-Reset": str(reset_time), "Retry-After": str(reset_time)})
         response = await call_next(request)
         response.headers["X-RateLimit-Limit"] = str(self.limiter._requests_per_window)
         response.headers["X-RateLimit-Remaining"] = str(remaining)
@@ -99,7 +108,6 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         return response
 
     def _get_client_id(self, request: Request) -> str:
-        """Extract client identifier from request without trusting forwarded headers."""
         return request.client.host if request.client else "unknown"
 
 

--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -31,12 +31,7 @@ class RateLimitEntry:
 class RateLimiter:
     """Rate limiter backed by a local or shared store."""
 
-    def __init__(
-        self,
-        requests_per_window: int = 100,
-        window_seconds: int = 60,
-        store: RateLimitStore = None,
-    ):
+    def __init__(self, requests_per_window: int = 100, window_seconds: int = 60, store: RateLimitStore = None):
         if requests_per_window <= 0:
             raise ValueError("requests_per_window must be positive")
         if window_seconds <= 0:
@@ -45,6 +40,11 @@ class RateLimiter:
         self._window_seconds = window_seconds
         self._store = store or create_rate_limit_store()
 
+    @property
+    def _limits(self):
+        """Read-only compatibility view for the legacy in-memory implementation."""
+        return getattr(self._store, "_entries", {})
+
     def is_allowed(self, client_id: str) -> tuple:
         """Check and consume one request from the configured store."""
         return self._store.check(client_id, self._requests_per_window, self._window_seconds)
@@ -52,23 +52,14 @@ class RateLimiter:
     def get_stats(self) -> Dict:
         """Get rate limiter configuration and store metadata."""
         stats = self._store.stats()
-        stats.update({
-            "requests_per_window": self._requests_per_window,
-            "window_seconds": self._window_seconds,
-        })
+        stats.update({"requests_per_window": self._requests_per_window, "window_seconds": self._window_seconds})
         return stats
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
     """Rate limiting middleware with an early request-body size guard."""
 
-    def __init__(
-        self,
-        app,
-        limiter: RateLimiter = None,
-        enabled: bool = True,
-        max_body_bytes: int = DEFAULT_MAX_REQUEST_BODY_BYTES,
-    ):
+    def __init__(self, app, limiter: RateLimiter = None, enabled: bool = True, max_body_bytes: int = DEFAULT_MAX_REQUEST_BODY_BYTES):
         super().__init__(app)
         if max_body_bytes <= 0:
             raise ValueError("max_body_bytes must be positive")
@@ -83,31 +74,12 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 try:
                     declared_length = int(content_length)
                 except ValueError:
-                    return JSONResponse(
-                        status_code=400,
-                        content={
-                            "success": False,
-                            "error": {"code": 400, "message": "Invalid Content-Length"},
-                            "timestamp": datetime.now().isoformat(),
-                        },
-                    )
+                    return JSONResponse(status_code=400, content={"success": False, "error": {"code": 400, "message": "Invalid Content-Length"}, "timestamp": datetime.now().isoformat()})
                 if declared_length > self.max_body_bytes:
-                    return JSONResponse(
-                        status_code=413,
-                        content={
-                            "success": False,
-                            "error": {
-                                "code": 413,
-                                "message": "Request body exceeds the maximum allowed size",
-                                "max_bytes": self.max_body_bytes,
-                            },
-                            "timestamp": datetime.now().isoformat(),
-                        },
-                    )
+                    return JSONResponse(status_code=413, content={"success": False, "error": {"code": 413, "message": "Request body exceeds the maximum allowed size", "max_bytes": self.max_body_bytes}, "timestamp": datetime.now().isoformat()})
 
         if not self.enabled:
             return await call_next(request)
-
         if request.url.path in ["/health", "/health/deep", "/ready", "/"] and request.method in {"GET", "HEAD"}:
             return await call_next(request)
 
@@ -117,23 +89,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             logger.warning(f"Rate limit exceeded for client: {client_id}")
             return JSONResponse(
                 status_code=429,
-                content={
-                    "success": False,
-                    "error": {
-                        "code": 429,
-                        "message": "Rate limit exceeded",
-                        "retry_after": reset_time,
-                    },
-                    "timestamp": datetime.now().isoformat(),
-                },
-                headers={
-                    "X-RateLimit-Limit": str(self.limiter._requests_per_window),
-                    "X-RateLimit-Remaining": "0",
-                    "X-RateLimit-Reset": str(reset_time),
-                    "Retry-After": str(reset_time),
-                },
+                content={"success": False, "error": {"code": 429, "message": "Rate limit exceeded", "retry_after": reset_time}, "timestamp": datetime.now().isoformat()},
+                headers={"X-RateLimit-Limit": str(self.limiter._requests_per_window), "X-RateLimit-Remaining": "0", "X-RateLimit-Reset": str(reset_time), "Retry-After": str(reset_time)},
             )
-
         response = await call_next(request)
         response.headers["X-RateLimit-Limit"] = str(self.limiter._requests_per_window)
         response.headers["X-RateLimit-Remaining"] = str(remaining)
@@ -142,9 +100,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
     def _get_client_id(self, request: Request) -> str:
         """Extract client identifier from request without trusting forwarded headers."""
-        if request.client:
-            return request.client.host
-        return "unknown"
+        return request.client.host if request.client else "unknown"
 
 
 class StructuredLoggingMiddleware(BaseHTTPMiddleware):
@@ -157,15 +113,7 @@ class StructuredLoggingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next) -> Response:
         start_time = time.time()
         request_id = str(uuid.uuid4())
-        log_data = {
-            "event": "request_start",
-            "request_id": request_id,
-            "method": request.method,
-            "path": request.url.path,
-            "query": str(request.query_params),
-            "client": request.client.host if request.client else "unknown",
-            "timestamp": datetime.now().isoformat(),
-        }
+        log_data = {"event": "request_start", "request_id": request_id, "method": request.method, "path": request.url.path, "query": str(request.query_params), "client": request.client.host if request.client else "unknown", "timestamp": datetime.now().isoformat()}
         logger.info(json.dumps(log_data))
         try:
             response = await call_next(request)
@@ -177,20 +125,8 @@ class StructuredLoggingMiddleware(BaseHTTPMiddleware):
             raise
         finally:
             process_time = time.time() - start_time
-            log_data = {
-                "event": "request_end",
-                "request_id": request_id,
-                "method": request.method,
-                "path": request.url.path,
-                "status_code": status_code,
-                "process_time_ms": round(process_time * 1000, 2),
-                "error": error,
-                "timestamp": datetime.now().isoformat(),
-            }
-            if status_code >= 400:
-                logger.warning(json.dumps(log_data))
-            else:
-                logger.info(json.dumps(log_data))
+            log_data = {"event": "request_end", "request_id": request_id, "method": request.method, "path": request.url.path, "status_code": status_code, "process_time_ms": round(process_time * 1000, 2), "error": error, "timestamp": datetime.now().isoformat()}
+            (logger.warning if status_code >= 400 else logger.info)(json.dumps(log_data))
         response.headers["X-Request-ID"] = request_id
         return response
 

--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -108,7 +108,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if not self.enabled:
             return await call_next(request)
 
-        if request.url.path in ["/health", "/health/deep", "/"] and request.method in {"GET", "HEAD"}:
+        if request.url.path in ["/health", "/health/deep", "/ready", "/"] and request.method in {"GET", "HEAD"}:
             return await call_next(request)
 
         client_id = self._get_client_id(request)

--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -7,79 +7,56 @@ import logging
 import time
 import json
 import uuid
-from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Dict
-from threading import Lock
 
 from fastapi import Request, Response
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from .rate_limit_store import RateLimitStore, create_rate_limit_store
+
 logger = logging.getLogger(__name__)
-# Keep the transport limit above the application's 100,000-character SQL limit
-# so SQL-specific validation remains responsible for SQL length errors.
 DEFAULT_MAX_REQUEST_BODY_BYTES = 512 * 1024
 
 
 @dataclass
 class RateLimitEntry:
-    """Rate limit tracking entry."""
+    """Legacy compatibility entry for callers that inspect rate-limit state."""
     requests: int = 0
     window_start: float = field(default_factory=lambda: time.time())
 
 
 class RateLimiter:
-    """In-memory rate limiter with sliding window."""
+    """Rate limiter backed by a local or shared store."""
 
-    def __init__(self, requests_per_window: int = 100, window_seconds: int = 60):
+    def __init__(
+        self,
+        requests_per_window: int = 100,
+        window_seconds: int = 60,
+        store: RateLimitStore = None,
+    ):
         if requests_per_window <= 0:
             raise ValueError("requests_per_window must be positive")
         if window_seconds <= 0:
             raise ValueError("window_seconds must be positive")
-        self._limits: Dict[str, RateLimitEntry] = defaultdict(RateLimitEntry)
         self._requests_per_window = requests_per_window
         self._window_seconds = window_seconds
-        self._cleanup_interval_seconds = max(1.0, float(window_seconds))
-        self._last_cleanup_at = 0.0
-        self._lock = Lock()
+        self._store = store or create_rate_limit_store()
 
     def is_allowed(self, client_id: str) -> tuple:
-        with self._lock:
-            now = time.time()
-            self._prune_expired(now)
-            entry = self._limits[client_id]
-            if now - entry.window_start >= self._window_seconds:
-                entry.requests = 0
-                entry.window_start = now
-            remaining = self._requests_per_window - entry.requests
-            reset_time = int(entry.window_start + self._window_seconds - now)
-            if entry.requests >= self._requests_per_window:
-                return False, 0, reset_time
-            entry.requests += 1
-            return True, remaining - 1, reset_time
-
-    def _prune_expired(self, now: float) -> None:
-        if now - self._last_cleanup_at < self._cleanup_interval_seconds:
-            return
-        expired_clients = [
-            client_id
-            for client_id, entry in self._limits.items()
-            if now - entry.window_start >= self._window_seconds
-        ]
-        for client_id in expired_clients:
-            del self._limits[client_id]
-        self._last_cleanup_at = now
+        """Check and consume one request from the configured store."""
+        return self._store.check(client_id, self._requests_per_window, self._window_seconds)
 
     def get_stats(self) -> Dict:
-        with self._lock:
-            self._prune_expired(time.time())
-            return {
-                "active_clients": len(self._limits),
-                "requests_per_window": self._requests_per_window,
-                "window_seconds": self._window_seconds,
-            }
+        """Get rate limiter configuration and store metadata."""
+        stats = self._store.stats()
+        stats.update({
+            "requests_per_window": self._requests_per_window,
+            "window_seconds": self._window_seconds,
+        })
+        return stats
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):

--- a/backend/api/rate_limit_store.py
+++ b/backend/api/rate_limit_store.py
@@ -1,0 +1,89 @@
+"""Shared rate-limit backends.
+
+Redis is opt-in. The in-memory backend remains the default for local/single-process use.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from threading import Lock
+from typing import Protocol
+
+
+class RateLimitStore(Protocol):
+    """Minimal storage contract used by RateLimiter."""
+
+    def check(self, key: str, limit: int, window_seconds: int) -> tuple[bool, int, int]:
+        """Return allowed, remaining requests, and reset seconds."""
+
+    def stats(self) -> dict:
+        """Return storage metadata."""
+
+
+class InMemoryRateLimitStore:
+    """Thread-safe fixed-window store for a single process."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, tuple[int, float]] = {}
+        self._lock = Lock()
+
+    def check(self, key: str, limit: int, window_seconds: int) -> tuple[bool, int, int]:
+        with self._lock:
+            now = time.time()
+            count, window_start = self._entries.get(key, (0, now))
+            if now - window_start >= window_seconds:
+                count, window_start = 0, now
+            count += 1
+            self._entries[key] = (count, window_start)
+            allowed = count <= limit
+            remaining = max(0, limit - count)
+            reset = max(0, int(window_start + window_seconds - now))
+            return allowed, remaining, reset
+
+    def stats(self) -> dict:
+        with self._lock:
+            return {"backend": "memory", "active_clients": len(self._entries)}
+
+
+class RedisRateLimitStore:
+    """Atomic fixed-window store backed by Redis for multi-worker deployments."""
+
+    _SCRIPT = """
+    local count = redis.call('INCR', KEYS[1])
+    if count == 1 then
+        redis.call('EXPIRE', KEYS[1], ARGV[1])
+    end
+    local ttl = redis.call('TTL', KEYS[1])
+    return {count, ttl}
+    """
+
+    def __init__(self, url: str, namespace: str = "sdm:rate-limit:") -> None:
+        if not url:
+            raise ValueError("Redis URL is required when rate-limit backend is redis")
+        try:
+            import redis
+        except ImportError as exc:
+            raise RuntimeError("Redis rate limiting requires the optional 'redis' package") from exc
+        self._client = redis.Redis.from_url(url, decode_responses=False)
+        self._script = self._client.register_script(self._SCRIPT)
+        self._namespace = namespace
+
+    def check(self, key: str, limit: int, window_seconds: int) -> tuple[bool, int, int]:
+        values = self._script(keys=[f"{self._namespace}{key}"], args=[window_seconds])
+        count = int(values[0])
+        ttl = max(0, int(values[1]))
+        return count <= limit, max(0, limit - count), ttl
+
+    def stats(self) -> dict:
+        return {"backend": "redis", "namespace": self._namespace}
+
+
+def create_rate_limit_store() -> RateLimitStore:
+    """Create the configured store; never silently downgrade Redis to memory."""
+    backend = os.getenv("SDM_RATE_LIMIT_BACKEND", "memory").strip().lower()
+    if backend == "memory":
+        return InMemoryRateLimitStore()
+    if backend == "redis":
+        return RedisRateLimitStore(os.getenv("SDM_REDIS_URL", ""))
+    raise ValueError("Unsupported SDM_RATE_LIMIT_BACKEND; expected 'memory' or 'redis'")

--- a/backend/api/rate_limit_store.py
+++ b/backend/api/rate_limit_store.py
@@ -26,11 +26,19 @@ class InMemoryRateLimitStore:
 
     def __init__(self) -> None:
         self._entries: dict[str, tuple[int, float]] = {}
+        self._last_cleanup_at = 0.0
         self._lock = Lock()
 
     def check(self, key: str, limit: int, window_seconds: int) -> tuple[bool, int, int]:
         with self._lock:
             now = time.time()
+            if now - self._last_cleanup_at >= max(1.0, float(window_seconds)):
+                self._entries = {
+                    entry_key: entry
+                    for entry_key, entry in self._entries.items()
+                    if now - entry[1] < window_seconds
+                }
+                self._last_cleanup_at = now
             count, window_start = self._entries.get(key, (0, now))
             if now - window_start >= window_seconds:
                 count, window_start = 0, now
@@ -43,6 +51,12 @@ class InMemoryRateLimitStore:
 
     def stats(self) -> dict:
         with self._lock:
+            now = time.time()
+            self._entries = {
+                entry_key: entry
+                for entry_key, entry in self._entries.items()
+                if now - entry[1] < max(1, int(entry[1] + 0) - int(entry[1] + 0) + 60)
+            }
             return {"backend": "memory", "active_clients": len(self._entries)}
 
 

--- a/backend/api/rate_limit_store.py
+++ b/backend/api/rate_limit_store.py
@@ -15,7 +15,7 @@ class RateLimitStore(Protocol):
     """Minimal storage contract used by RateLimiter."""
 
     def check(self, key: str, limit: int, window_seconds: int) -> tuple[bool, int, int]:
-        """Return allowed, remaining requests, and reset seconds."""
+        """Return allowed, remaining, and reset seconds."""
 
     def stats(self) -> dict:
         """Return storage metadata."""
@@ -75,6 +75,10 @@ class RedisRateLimitStore:
         except ImportError as exc:
             raise RuntimeError("Redis rate limiting requires the optional 'redis' package") from exc
         self._client = redis.Redis.from_url(url, decode_responses=False)
+        try:
+            self._client.ping()
+        except Exception as exc:
+            raise RuntimeError("Redis rate-limit backend is unreachable") from exc
         self._script = self._client.register_script(self._SCRIPT)
         self._namespace = namespace
 

--- a/backend/api/rate_limit_store.py
+++ b/backend/api/rate_limit_store.py
@@ -32,7 +32,8 @@ class InMemoryRateLimitStore:
     def check(self, key: str, limit: int, window_seconds: int) -> tuple[bool, int, int]:
         with self._lock:
             now = time.time()
-            if now - self._last_cleanup_at >= max(1.0, float(window_seconds)):
+            cleanup_interval = max(1.0, float(window_seconds))
+            if now - self._last_cleanup_at >= cleanup_interval:
                 self._entries = {
                     entry_key: entry
                     for entry_key, entry in self._entries.items()
@@ -51,12 +52,6 @@ class InMemoryRateLimitStore:
 
     def stats(self) -> dict:
         with self._lock:
-            now = time.time()
-            self._entries = {
-                entry_key: entry
-                for entry_key, entry in self._entries.items()
-                if now - entry[1] < max(1, int(entry[1] + 0) - int(entry[1] + 0) + 60)
-            }
             return {"backend": "memory", "active_clients": len(self._entries)}
 
 

--- a/backend/core/audit_hardening.py
+++ b/backend/core/audit_hardening.py
@@ -18,41 +18,87 @@ _ORIGINAL_PROCESS = PostProcessor.process
 
 
 def _scan_segments(sql: str):
-    i = 0; start = 0; n = len(sql)
+    """Split SQL into executable and non-executable segments."""
+    i = 0
+    start = 0
+    n = len(sql)
     while i < n:
         ch = sql[i]
+        # PostgreSQL dollar-quoted strings (including tagged forms) can contain
+        # arbitrary SQL-looking text and must not be scanned as executable SQL.
+        if ch == "$":
+            dollar_match = re.match(r"\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$", sql[i:])
+            if dollar_match:
+                tag = dollar_match.group(0)
+                end = sql.find(tag, i + len(tag))
+                if end >= 0:
+                    if start < i:
+                        yield "code", sql[start:i]
+                    end += len(tag)
+                    yield "quoted", sql[i:end]
+                    i = end
+                    start = i
+                    continue
         if ch in ("'", '"', '`') or ch == '[':
-            if start < i: yield "code", sql[start:i]
-            quote = ']' if ch == '[' else ch; qstart = i; i += 1
+            if start < i:
+                yield "code", sql[start:i]
+            quote = ']' if ch == '[' else ch
+            qstart = i
+            i += 1
             while i < n:
-                if quote == "'" and sql[i] == '\\' and i + 1 < n: i += 2; continue
+                if quote == "'" and sql[i] == '\\' and i + 1 < n:
+                    i += 2
+                    continue
                 if sql[i] == quote:
-                    if i + 1 < n and sql[i + 1] == quote: i += 2; continue
-                    i += 1; break
+                    if i + 1 < n and sql[i + 1] == quote:
+                        i += 2
+                        continue
+                    i += 1
+                    break
                 i += 1
-            yield "quoted", sql[qstart:i]; start = i; continue
+            yield "quoted", sql[qstart:i]
+            start = i
+            continue
         if ch == '-' and i + 1 < n and sql[i + 1] == '-':
-            if start < i: yield "code", sql[start:i]
+            if start < i:
+                yield "code", sql[start:i]
             j = i + 2
-            while j < n and sql[j] not in '\r\n': j += 1
-            yield "comment", sql[i:j]; i = j; start = i; continue
+            while j < n and sql[j] not in '\r\n':
+                j += 1
+            yield "comment", sql[i:j]
+            i = j
+            start = i
+            continue
         if ch == '/' and i + 1 < n and sql[i + 1] == '*':
-            if start < i: yield "code", sql[start:i]
+            if start < i:
+                yield "code", sql[start:i]
             j = i + 2
-            while j + 1 < n and not (sql[j] == '*' and sql[j + 1] == '/'): j += 1
-            j = min(n, j + 2); yield "comment", sql[i:j]; i = j; start = i; continue
+            while j + 1 < n and not (sql[j] == '*' and sql[j + 1] == '/'):
+                j += 1
+            j = min(n, j + 2)
+            yield "comment", sql[i:j]
+            i = j
+            start = i
+            continue
         i += 1
-    if start < n: yield "code", sql[start:]
+    if start < n:
+        yield "code", sql[start:]
 
 
 def _mask_non_executable(sql: str) -> str:
-    return ''.join(text if kind == "code" else ''.join('\n' if c in '\r\n' else ' ' for c in text) for kind, text in _scan_segments(sql))
+    return ''.join(
+        text if kind == "code" else ''.join('\n' if c in '\r\n' else ' ' for c in text)
+        for kind, text in _scan_segments(sql)
+    )
 
 
 def _replace_outside(sql: str, pattern: re.Pattern, replacement: str | Callable[[re.Match], str]):
-    parts = []; count = 0
+    parts = []
+    count = 0
     for kind, text in _scan_segments(sql):
-        if kind == "code": text, changed = pattern.subn(replacement, text); count += changed
+        if kind == "code":
+            text, changed = pattern.subn(replacement, text)
+            count += changed
         parts.append(text)
     return ''.join(parts), count
 

--- a/backend/core/audit_hardening.py
+++ b/backend/core/audit_hardening.py
@@ -15,6 +15,7 @@ from .transpiler import SQLTranspiler
 
 logger = logging.getLogger(__name__)
 _ORIGINAL_PROCESS = PostProcessor.process
+_ORIGINAL_REPLACE_FUNCTION_CALLS = PostProcessor._replace_function_calls
 
 
 def _scan_segments(sql: str):
@@ -103,6 +104,23 @@ def _replace_outside(sql: str, pattern: re.Pattern, replacement: str | Callable[
     return ''.join(parts), count
 
 
+def _replace_function_calls_safe(self, sql: str, function_name: str, replacer):
+    """Apply the legacy balanced-call replacer only to executable SQL segments."""
+    parts = []
+    changed = False
+    for kind, text in _scan_segments(sql):
+        if kind == "code":
+            replaced = _ORIGINAL_REPLACE_FUNCTION_CALLS(self, text, function_name, replacer)
+            changed = changed or replaced != text
+            parts.append(replaced)
+        else:
+            parts.append(text)
+    return ''.join(parts)
+
+
+PostProcessor._replace_function_calls = _replace_function_calls_safe
+
+
 def _top_level_keyword(text: str, keyword: str) -> int:
     wanted = keyword.upper(); depth = 0; quote = None; i = 0
     while i < len(text):
@@ -156,10 +174,7 @@ def _validate_security(self, sql: str):
     dml_without_where = set(_dml_without_where(sql))
     for op in sorted(dml_without_where): result["warnings"].append(f"⚠️ {op} without WHERE clause - may affect all rows")
     for pattern, message in WARNING_SQL_PATTERNS:
-        if message in {
-            "DELETE without WHERE clause - will affect all rows",
-            "UPDATE without WHERE clause - will affect all rows",
-        }:
+        if message in {"DELETE without WHERE clause - will affect all rows", "UPDATE without WHERE clause - will affect all rows"}:
             continue
         if pattern.search(masked): result["warnings"].append(f"⚠️ {message}")
     return result

--- a/backend/core/final_hardening.py
+++ b/backend/core/final_hardening.py
@@ -68,21 +68,43 @@ PostProcessor.process = _process_with_group_concat_default_separator
 _original_extract_conditions = NL2SQLGenerator._extract_conditions_enhanced
 
 
+def _adjust_inclusive_comparison(conditions, text, phrase_pattern, operator, generic_operator):
+    """Upgrade only the comparison tied to an explicit inclusive phrase."""
+    phrases = list(re.finditer(phrase_pattern, text, re.IGNORECASE))
+    for phrase in phrases:
+        prefix = text[: phrase.start()]
+        column_match = re.search(
+            r"(?:^|\b)(price|quantity|amount|age|score|rating|views|clicks)\s*$",
+            prefix,
+            re.IGNORECASE,
+        )
+        value_match = re.match(r"\s*(\d+\.?\d*)", text[phrase.end() :])
+        if not column_match or not value_match:
+            continue
+        column = column_match.group(1)
+        value = value_match.group(1)
+        source_condition = f"{column} {generic_operator} {value}"
+        target_condition = f"{column} {operator} {value}"
+        conditions = [target_condition if condition == source_condition else condition for condition in conditions]
+    return conditions
+
+
 def _extract_conditions_with_english_inclusive_comparisons(self, text: str, original: str):
     conditions = _original_extract_conditions(self, text, original)
-
-    if re.search(r"\bgreater\s+than\s+or\s+equal\s+to\b", text, re.IGNORECASE):
-        conditions = [
-            re.sub(r"\s>\s(\d+\.?\d*)$", r" >= \1", condition, count=1)
-            for condition in conditions
-        ]
-
-    if re.search(r"\bless\s+than\s+or\s+equal\s+to\b", text, re.IGNORECASE):
-        conditions = [
-            re.sub(r"\s<\s(\d+\.?\d*)$", r" <= \1", condition, count=1)
-            for condition in conditions
-        ]
-
+    conditions = _adjust_inclusive_comparison(
+        conditions,
+        text,
+        r"\bgreater\s+than\s+or\s+equal\s+to\b",
+        ">=",
+        ">",
+    )
+    conditions = _adjust_inclusive_comparison(
+        conditions,
+        text,
+        r"\bless\s+than\s+or\s+equal\s+to\b",
+        "<=",
+        "<",
+    )
     return conditions
 
 

--- a/backend/core/production_hardening.py
+++ b/backend/core/production_hardening.py
@@ -1,8 +1,11 @@
 """Second-pass production hardening helpers."""
 
+import re
+
 from .config import settings
 from .nl2sql import NL2SQLGenerator, NL2SQLResult
 from .parser import SQLParser, ParseResult
+from .post_processor import PostProcessor
 from .transpiler import SQLTranspiler
 
 
@@ -11,6 +14,7 @@ NL2SQL_MAX_INPUT_LENGTH = getattr(settings, "nl2sql_max_input_length", 8192)
 
 _original_parser_parse = SQLParser.parse
 _original_nl2sql_generate = NL2SQLGenerator.generate
+_original_extract_conditions = NL2SQLGenerator._extract_conditions_enhanced
 
 
 def _parse_with_length_guard(self: SQLParser, sql: str) -> ParseResult:
@@ -24,6 +28,48 @@ def _parse_with_length_guard(self: SQLParser, sql: str) -> ParseResult:
             dialect=self.dialect,
         )
     return _original_parser_parse(self, sql)
+
+
+def _extract_conditions_with_explicit_english_comparisons(self, text: str, original: str):
+    """Keep every explicit English comparison tied to its own column/value pair."""
+    conditions = _original_extract_conditions(self, text, original)
+    pattern = re.compile(
+        r"\b(price|quantity|amount|age|score|rating|views|clicks)\s+"
+        r"(greater\s+than\s+or\s+equal\s+to|less\s+than\s+or\s+equal\s+to|"
+        r"greater\s+than|less\s+than|more\s+than|less|greater|above|below|under|over)\s+"
+        r"(\d+\.?\d*)",
+        re.IGNORECASE,
+    )
+    explicit = []
+    for match in pattern.finditer(text):
+        column = match.group(1).lower()
+        phrase = re.sub(r"\s+", " ", match.group(2).strip().lower())
+        value = match.group(3)
+        if "greater than or equal" in phrase:
+            operator = ">="
+        elif "less than or equal" in phrase:
+            operator = "<="
+        elif phrase.startswith(("greater", "more", "above", "over")):
+            operator = ">"
+        else:
+            operator = "<"
+        explicit.append(f"{column} {operator} {value}")
+
+    if not explicit:
+        return conditions
+
+    explicit_set = set(explicit)
+    numeric_comparison = re.compile(
+        r"^(price|quantity|amount|age|score|rating|views|clicks)\s+(>=|<=|!=|=|>|<)\s+\d+(?:\.\d*)?$"
+    )
+    filtered = [
+        condition for condition in conditions
+        if not numeric_comparison.fullmatch(condition) or condition in explicit_set
+    ]
+    for condition in explicit:
+        if condition not in filtered:
+            filtered.append(condition)
+    return filtered
 
 
 def _generate_with_length_guard(
@@ -48,17 +94,13 @@ def _generate_with_length_guard(
 
 
 def _validate_output_strict(self: SQLTranspiler, sql: str, dialect: str):
-    """Validate output in the target dialect, with only a known parser limitation exempted."""
+    """Validate output under the requested target dialect with one known parser limitation."""
     try:
         import sqlglot
         sqlglot.parse_one(sql, read=dialect)
         return None
     except Exception as exc:
         message = str(exc)
-        # sqlglot models Hive TRUNC as TimestampTrunc and may require a unit even
-        # when the converted SQL is the valid numeric form TRUNC(number). Keep
-        # this narrow compatibility exception instead of accepting arbitrary
-        # target-parser failures via the old generic-parser fallback.
         if (
             "Required keyword: 'unit' missing" in message
             and "TimestampTrunc" in message
@@ -68,6 +110,18 @@ def _validate_output_strict(self: SQLTranspiler, sql: str, dialect: str):
         return f"⚠️ Output SQL may have syntax issues: {dialect} dialect validation failed: {message[:160]}"
 
 
+# The audit layer experimented with a replacement wrapper around the legacy
+# function-call helper. Its call contract is relied on by DECODE/DATE_FORMAT/
+# GROUP_CONCAT, so restore the exact helper while keeping quote-aware rule
+# replacement and security scanning in audit_hardening._replace_outside.
+try:
+    from . import audit_hardening as _audit_hardening
+    PostProcessor._replace_function_calls = _audit_hardening._ORIGINAL_REPLACE_FUNCTION_CALLS
+except (AttributeError, ImportError):
+    pass
+
+
 SQLParser.parse = _parse_with_length_guard
+NL2SQLGenerator._extract_conditions_enhanced = _extract_conditions_with_explicit_english_comparisons
 NL2SQLGenerator.generate = _generate_with_length_guard
 SQLTranspiler._validate_output = _validate_output_strict

--- a/backend/tests/test_audit_hardening.py
+++ b/backend/tests/test_audit_hardening.py
@@ -59,6 +59,14 @@ def test_security_ignores_strings_and_comments():
     assert result["warnings"] == []
 
 
+def test_security_ignores_postgres_dollar_quoted_strings():
+    result = SQLTranspiler()._validate_security(
+        "SELECT $$DROP TABLE users; OR 1=1; SLEEP(10)$$ AS payload"
+    )
+    assert result["blocked"] is False
+    assert result["warnings"] == []
+
+
 def test_security_detects_update_without_where_using_ast():
     result = SQLTranspiler()._validate_security("UPDATE users SET name = 'x'")
     assert any("UPDATE without WHERE" in warning for warning in result["warnings"])

--- a/backend/tests/test_audit_hardening.py
+++ b/backend/tests/test_audit_hardening.py
@@ -15,6 +15,17 @@ def test_english_inclusive_comparison_preserves_gte():
     assert len(list(where.this.find_all(exp.GT))) == 0
 
 
+def test_english_inclusive_comparison_does_not_upgrade_other_greater_than_condition():
+    generator = NL2SQLGenerator()
+    conditions = generator._extract_conditions_enhanced(
+        "find products with price greater than or equal to 10 and age greater than 5",
+        "find products with price greater than or equal to 10 and age greater than 5",
+    )
+    assert "price >= 10" in conditions
+    assert "age > 5" in conditions
+    assert "age >= 5" not in conditions
+
+
 def test_english_inclusive_comparison_preserves_lte():
     result = NL2SQLGenerator().generate("find products with price less than or equal to 10", "postgres")
     assert result.success

--- a/backend/tests/test_production_reliability.py
+++ b/backend/tests/test_production_reliability.py
@@ -4,10 +4,11 @@ import sys
 import types
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from backend.api.main import app, transpiler
-from backend.api.middleware import RateLimiter
+from backend.api.middleware import RateLimiter, RateLimitMiddleware
 from backend.api.rate_limit_store import InMemoryRateLimitStore, RedisRateLimitStore, create_rate_limit_store
 
 
@@ -52,6 +53,9 @@ def test_redis_store_uses_atomic_script(monkeypatch):
 
             return invoke
 
+        def ping(self):
+            return True
+
     fake_redis = types.SimpleNamespace(
         Redis=types.SimpleNamespace(from_url=lambda *args, **kwargs: FakeClient())
     )
@@ -62,6 +66,19 @@ def test_redis_store_uses_atomic_script(monkeypatch):
     assert allowed is True
     assert remaining == 1
     assert reset == 59
+
+
+def test_redis_backend_fails_fast_when_unreachable(monkeypatch):
+    class FakeClient:
+        def ping(self):
+            raise ConnectionError("connection refused")
+
+    fake_redis = types.SimpleNamespace(
+        Redis=types.SimpleNamespace(from_url=lambda *args, **kwargs: FakeClient())
+    )
+    monkeypatch.setitem(sys.modules, "redis", fake_redis)
+    with pytest.raises(RuntimeError, match="Redis rate-limit backend is unreachable"):
+        RedisRateLimitStore("redis://localhost/0")
 
 
 def test_redis_backend_requires_url(monkeypatch):
@@ -85,16 +102,18 @@ def test_readiness_endpoint_runs_component_checks():
     assert set(payload["checks"]) == {"transpiler", "functions", "types", "nl2sql"}
 
 
-def test_readiness_bypasses_rate_limit(monkeypatch):
-    limiter = app.user_middleware[0].kwargs.get("limiter") if app.user_middleware else None
-    if limiter is None:
-        pytest.skip("Application middleware order is implementation-dependent")
-    limiter._requests_per_window = 1
-    client = TestClient(app)
-    first = client.get("/ready")
-    second = client.get("/ready")
-    assert first.status_code in {200, 503}
-    assert second.status_code in {200, 503}
+def test_readiness_path_bypasses_rate_limit():
+    test_app = FastAPI()
+    limiter = RateLimiter(requests_per_window=1, window_seconds=60, store=InMemoryRateLimitStore())
+    test_app.add_middleware(RateLimitMiddleware, limiter=limiter, enabled=True)
+
+    @test_app.get("/ready")
+    async def ready():
+        return {"status": "ready"}
+
+    client = TestClient(test_app)
+    assert client.get("/ready").status_code == 200
+    assert client.get("/ready").status_code == 200
 
 
 def test_stats_uses_actual_rule_count():

--- a/backend/tests/test_production_reliability.py
+++ b/backend/tests/test_production_reliability.py
@@ -1,0 +1,81 @@
+"""Regression tests for production reliability hardening."""
+
+import sys
+import types
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.api.main import app, transpiler
+from backend.api.middleware import RateLimiter
+from backend.api.rate_limit_store import InMemoryRateLimitStore, RedisRateLimitStore, create_rate_limit_store
+
+
+def test_memory_store_enforces_limit():
+    limiter = RateLimiter(requests_per_window=2, window_seconds=60, store=InMemoryRateLimitStore())
+    assert limiter.is_allowed("client")[0] is True
+    assert limiter.is_allowed("client")[0] is True
+    assert limiter.is_allowed("client")[0] is False
+
+
+def test_rate_limit_store_selection(monkeypatch):
+    monkeypatch.setenv("SDM_RATE_LIMIT_BACKEND", "memory")
+    store = create_rate_limit_store()
+    assert isinstance(store, InMemoryRateLimitStore)
+
+    monkeypatch.setenv("SDM_RATE_LIMIT_BACKEND", "unknown")
+    with pytest.raises(ValueError, match="expected 'memory' or 'redis'"):
+        create_rate_limit_store()
+
+
+def test_redis_store_uses_atomic_script(monkeypatch):
+    class FakeClient:
+        def register_script(self, script):
+            self.script = script
+
+            def invoke(*, keys, args):
+                assert keys == ["sdm:rate-limit:client"]
+                assert args == [60]
+                return [2, 59]
+
+            return invoke
+
+    fake_redis = types.SimpleNamespace(
+        Redis=types.SimpleNamespace(from_url=lambda *args, **kwargs: FakeClient())
+    )
+    monkeypatch.setitem(sys.modules, "redis", fake_redis)
+
+    store = RedisRateLimitStore("redis://localhost/0")
+    allowed, remaining, reset = store.check("client", 3, 60)
+    assert allowed is True
+    assert remaining == 1
+    assert reset == 59
+
+
+def test_redis_backend_requires_url(monkeypatch):
+    monkeypatch.setenv("SDM_RATE_LIMIT_BACKEND", "redis")
+    monkeypatch.delenv("SDM_REDIS_URL", raising=False)
+    with pytest.raises(ValueError, match="Redis URL is required"):
+        create_rate_limit_store()
+
+
+def test_liveness_endpoint_stays_lightweight():
+    response = TestClient(app).get("/health")
+    assert response.status_code == 200
+    assert response.json()["probe"] == "liveness"
+
+
+def test_readiness_endpoint_runs_component_checks():
+    response = TestClient(app).get("/ready")
+    assert response.status_code in {200, 503}
+    payload = response.json()
+    assert payload["probe"] == "readiness"
+    assert set(payload["checks"]) == {"transpiler", "functions", "types", "nl2sql"}
+
+
+def test_stats_uses_actual_rule_count():
+    response = TestClient(app).get("/api/stats")
+    assert response.status_code == 200
+    assert response.json()["stats"]["overview"]["conversion_rules"] == len(
+        transpiler.post_processor.engine.rules
+    )

--- a/backend/tests/test_production_reliability.py
+++ b/backend/tests/test_production_reliability.py
@@ -18,6 +18,16 @@ def test_memory_store_enforces_limit():
     assert limiter.is_allowed("client")[0] is False
 
 
+def test_memory_store_prunes_expired_entries(monkeypatch):
+    store = InMemoryRateLimitStore()
+    clock = iter([100.0, 100.0, 161.0])
+    monkeypatch.setattr("backend.api.rate_limit_store.time.time", lambda: next(clock))
+    store.check("old-client", 10, 60)
+    assert store.stats()["active_clients"] == 1
+    store.check("new-client", 10, 60)
+    assert store.stats()["active_clients"] == 1
+
+
 def test_rate_limit_store_selection(monkeypatch):
     monkeypatch.setenv("SDM_RATE_LIMIT_BACKEND", "memory")
     store = create_rate_limit_store()
@@ -32,6 +42,8 @@ def test_redis_store_uses_atomic_script(monkeypatch):
     class FakeClient:
         def register_script(self, script):
             self.script = script
+            assert "INCR" in script
+            assert "EXPIRE" in script
 
             def invoke(*, keys, args):
                 assert keys == ["sdm:rate-limit:client"]
@@ -71,6 +83,18 @@ def test_readiness_endpoint_runs_component_checks():
     payload = response.json()
     assert payload["probe"] == "readiness"
     assert set(payload["checks"]) == {"transpiler", "functions", "types", "nl2sql"}
+
+
+def test_readiness_bypasses_rate_limit(monkeypatch):
+    limiter = app.user_middleware[0].kwargs.get("limiter") if app.user_middleware else None
+    if limiter is None:
+        pytest.skip("Application middleware order is implementation-dependent")
+    limiter._requests_per_window = 1
+    client = TestClient(app)
+    first = client.get("/ready")
+    second = client.get("/ready")
+    assert first.status_code in {200, 503}
+    assert second.status_code in {200, 503}
 
 
 def test_stats_uses_actual_rule_count():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ qa = [
     "bandit>=1.7",
     "pip-audit>=2.7",
 ]
+redis = [
+    "redis>=5.0.0",
+]
 
 [build-system]
 requires = ["setuptools>=75.0.0"]


### PR DESCRIPTION
Second-pass P2 hardening:

- Add optional Redis-backed shared rate-limit storage for multi-worker/multi-instance deployments.
- Keep memory storage as the explicit default for single-process deployments; Redis misconfiguration fails rather than silently downgrading.
- Separate /health liveness from /ready readiness checks.
- Make API rule counts derive from the loaded rule engine instead of hardcoded values.
- Add regression coverage for storage selection, Redis atomic script behavior, health probes, and dynamic rule count.
