### PR TITLE
fix: make rate limiting multi-worker safe

### DIFF
--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -7,91 +7,57 @@ import logging
 import time
 import json
 import uuid
-from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Dict
-from threading import Lock
 
 from fastapi import Request, Response
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from .rate_limit_store import RateLimitStore, create_rate_limit_store
+
 logger = logging.getLogger(__name__)
-# Keep the transport limit above the application's 100,000-character SQL limit
-# so SQL-specific validation remains responsible for SQL length errors.
 DEFAULT_MAX_REQUEST_BODY_BYTES = 512 * 1024
 
 
 @dataclass
 class RateLimitEntry:
-    """Rate limit tracking entry."""
+    """Legacy compatibility entry."""
     requests: int = 0
     window_start: float = field(default_factory=lambda: time.time())
 
 
 class RateLimiter:
-    """In-memory rate limiter with sliding window."""
+    """Rate limiter backed by a local or shared store."""
 
-    def __init__(self, requests_per_window: int = 100, window_seconds: int = 60):
+    def __init__(self, requests_per_window: int = 100, window_seconds: int = 60, store: RateLimitStore = None):
         if requests_per_window <= 0:
             raise ValueError("requests_per_window must be positive")
         if window_seconds <= 0:
             raise ValueError("window_seconds must be positive")
-        self._limits: Dict[str, RateLimitEntry] = defaultdict(RateLimitEntry)
         self._requests_per_window = requests_per_window
         self._window_seconds = window_seconds
-        self._cleanup_interval_seconds = max(1.0, float(window_seconds))
-        self._last_cleanup_at = 0.0
-        self._lock = Lock()
+        self._store = store or create_rate_limit_store()
+
+    @property
+    def _limits(self):
+        """Read-only compatibility view for the in-memory backend."""
+        return getattr(self._store, "_entries", {})
 
     def is_allowed(self, client_id: str) -> tuple:
-        with self._lock:
-            now = time.time()
-            self._prune_expired(now)
-            entry = self._limits[client_id]
-            if now - entry.window_start >= self._window_seconds:
-                entry.requests = 0
-                entry.window_start = now
-            remaining = self._requests_per_window - entry.requests
-            reset_time = int(entry.window_start + self._window_seconds - now)
-            if entry.requests >= self._requests_per_window:
-                return False, 0, reset_time
-            entry.requests += 1
-            return True, remaining - 1, reset_time
-
-    def _prune_expired(self, now: float) -> None:
-        if now - self._last_cleanup_at < self._cleanup_interval_seconds:
-            return
-        expired_clients = [
-            client_id
-            for client_id, entry in self._limits.items()
-            if now - entry.window_start >= self._window_seconds
-        ]
-        for client_id in expired_clients:
-            del self._limits[client_id]
-        self._last_cleanup_at = now
+        return self._store.check(client_id, self._requests_per_window, self._window_seconds)
 
     def get_stats(self) -> Dict:
-        with self._lock:
-            self._prune_expired(time.time())
-            return {
-                "active_clients": len(self._limits),
-                "requests_per_window": self._requests_per_window,
-                "window_seconds": self._window_seconds,
-            }
+        stats = self._store.stats()
+        stats.update({"requests_per_window": self._requests_per_window, "window_seconds": self._window_seconds})
+        return stats
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
-    """Rate limiting middleware with an early request-body size guard."""
+    """Rate limiting middleware with a bounded request-body guard."""
 
-    def __init__(
-        self,
-        app,
-        limiter: RateLimiter = None,
-        enabled: bool = True,
-        max_body_bytes: int = DEFAULT_MAX_REQUEST_BODY_BYTES,
-    ):
+    def __init__(self, app, limiter: RateLimiter = None, enabled: bool = True, max_body_bytes: int = DEFAULT_MAX_REQUEST_BODY_BYTES):
         super().__init__(app)
         if max_body_bytes <= 0:
             raise ValueError("max_body_bytes must be positive")
@@ -99,39 +65,36 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self.enabled = enabled
         self.max_body_bytes = max_body_bytes
 
-    async def dispatch(self, request: Request, call_next) -> Response:
-        if request.method not in {"GET", "HEAD"}:
-            content_length = request.headers.get("content-length")
-            if content_length:
-                try:
-                    declared_length = int(content_length)
-                except ValueError:
-                    return JSONResponse(
-                        status_code=400,
-                        content={
-                            "success": False,
-                            "error": {"code": 400, "message": "Invalid Content-Length"},
-                            "timestamp": datetime.now().isoformat(),
-                        },
-                    )
-                if declared_length > self.max_body_bytes:
-                    return JSONResponse(
-                        status_code=413,
-                        content={
-                            "success": False,
-                            "error": {
-                                "code": 413,
-                                "message": "Request body exceeds the maximum allowed size",
-                                "max_bytes": self.max_body_bytes,
-                            },
-                            "timestamp": datetime.now().isoformat(),
-                        },
-                    )
+    async def _read_bounded_body(self, request: Request) -> Response | None:
+        """Consume and cache request bodies without trusting Content-Length."""
+        if request.method in {"GET", "HEAD"}:
+            return None
+        content_length = request.headers.get("content-length")
+        if content_length:
+            try:
+                declared_length = int(content_length)
+            except ValueError:
+                return JSONResponse(status_code=400, content={"success": False, "error": {"code": 400, "message": "Invalid Content-Length"}, "timestamp": datetime.now().isoformat()})
+            if declared_length > self.max_body_bytes:
+                return JSONResponse(status_code=413, content={"success": False, "error": {"code": 413, "message": "Request body exceeds the maximum allowed size", "max_bytes": self.max_body_bytes}, "timestamp": datetime.now().isoformat()})
 
+        total = 0
+        chunks = []
+        async for chunk in request.stream():
+            total += len(chunk)
+            if total > self.max_body_bytes:
+                return JSONResponse(status_code=413, content={"success": False, "error": {"code": 413, "message": "Request body exceeds the maximum allowed size", "max_bytes": self.max_body_bytes}, "timestamp": datetime.now().isoformat()})
+            chunks.append(chunk)
+        request._body = b"".join(chunks)
+        return None
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        body_error = await self._read_bounded_body(request)
+        if body_error is not None:
+            return body_error
         if not self.enabled:
             return await call_next(request)
-
-        if request.url.path in ["/health", "/health/deep", "/"] and request.method in {"GET", "HEAD"}:
+        if request.url.path in ["/health", "/health/deep", "/ready", "/"] and request.method in {"GET", "HEAD"}:
             return await call_next(request)
 
         client_id = self._get_client_id(request)
@@ -140,23 +103,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             logger.warning(f"Rate limit exceeded for client: {client_id}")
             return JSONResponse(
                 status_code=429,
-                content={
-                    "success": False,
-                    "error": {
-                        "code": 429,
-                        "message": "Rate limit exceeded",
-                        "retry_after": reset_time,
-                    },
-                    "timestamp": datetime.now().isoformat(),
-                },
-                headers={
-                    "X-RateLimit-Limit": str(self.limiter._requests_per_window),
-                    "X-RateLimit-Remaining": "0",
-                    "X-RateLimit-Reset": str(reset_time),
-                    "Retry-After": str(reset_time),
-                },
+                content={"success": False, "error": {"code": 429, "message": "Rate limit exceeded", "retry_after": reset_time}, "timestamp": datetime.now().isoformat()},
+                headers={"X-RateLimit-Limit": str(self.limiter._requests_per_window), "X-RateLimit-Remaining": "0", "X-RateLimit-Reset": str(reset_time), "Retry-After": str(reset_time)},
             )
-
         response = await call_next(request)
         response.headers["X-RateLimit-Limit"] = str(self.limiter._requests_per_window)
         response.headers["X-RateLimit-Remaining"] = str(remaining)
@@ -164,10 +113,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         return response
 
     def _get_client_id(self, request: Request) -> str:
-        """Extract client identifier from request without trusting forwarded headers."""
-        if request.client:
-            return request.client.host
-        return "unknown"
+        return request.client.host if request.client else "unknown"
 
 
 class StructuredLoggingMiddleware(BaseHTTPMiddleware):
@@ -180,15 +126,7 @@ class StructuredLoggingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next) -> Response:
         start_time = time.time()
         request_id = str(uuid.uuid4())
-        log_data = {
-            "event": "request_start",
-            "request_id": request_id,
-            "method": request.method,
-            "path": request.url.path,
-            "query": str(request.query_params),
-            "client": request.client.host if request.client else "unknown",
-            "timestamp": datetime.now().isoformat(),
-        }
+        log_data = {"event": "request_start", "request_id": request_id, "method": request.method, "path": request.url.path, "query": str(request.query_params), "client": request.client.host if request.client else "unknown", "timestamp": datetime.now().isoformat()}
         logger.info(json.dumps(log_data))
         try:
             response = await call_next(request)
@@ -200,20 +138,8 @@ class StructuredLoggingMiddleware(BaseHTTPMiddleware):
             raise
         finally:
             process_time = time.time() - start_time
-            log_data = {
-                "event": "request_end",
-                "request_id": request_id,
-                "method": request.method,
-                "path": request.url.path,
-                "status_code": status_code,
-                "process_time_ms": round(process_time * 1000, 2),
-                "error": error,
-                "timestamp": datetime.now().isoformat(),
-            }
-            if status_code >= 400:
-                logger.warning(json.dumps(log_data))
-            else:
-                logger.info(json.dumps(log_data))
+            log_data = {"event": "request_end", "request_id": request_id, "method": request.method, "path": request.url.path, "status_code": status_code, "process_time_ms": round(process_time * 1000, 2), "error": error, "timestamp": datetime.now().isoformat()}
+            (logger.warning if status_code >= 400 else logger.info)(json.dumps(log_data))
         response.headers["X-Request-ID"] = request_id
         return response
 

--- a/backend/api/rate_limit_store.py
+++ b/backend/api/rate_limit_store.py
@@ -26,28 +26,38 @@ class InMemoryRateLimitStore:
 
     def __init__(self) -> None:
         self._entries: dict[str, tuple[int, float]] = {}
-        self._last_cleanup_at = 0.0
+        self._expirations: dict[str, float] = {}
+        self._next_cleanup_at = 0.0
         self._lock = Lock()
+
+    def _prune_expired(self, now: float) -> None:
+        if now < self._next_cleanup_at:
+            return
+        expired_keys = [
+            key for key, expires_at in self._expirations.items() if expires_at <= now
+        ]
+        for key in expired_keys:
+            self._entries.pop(key, None)
+            self._expirations.pop(key, None)
+        self._next_cleanup_at = min(self._expirations.values(), default=float("inf"))
 
     def check(self, key: str, limit: int, window_seconds: int) -> tuple[bool, int, int]:
         with self._lock:
             now = time.time()
-            if now - self._last_cleanup_at >= max(1.0, float(window_seconds)):
-                self._entries = {
-                    entry_key: entry
-                    for entry_key, entry in self._entries.items()
-                    if now - entry[1] < window_seconds
-                }
-                self._last_cleanup_at = now
+            self._prune_expired(now)
             count, window_start = self._entries.get(key, (0, now))
             if now - window_start >= window_seconds:
                 count, window_start = 0, now
             count += 1
+            expires_at = window_start + window_seconds
             self._entries[key] = (count, window_start)
-            return count <= limit, max(0, limit - count), max(0, int(window_start + window_seconds - now))
+            self._expirations[key] = expires_at
+            self._next_cleanup_at = min(self._next_cleanup_at, expires_at)
+            return count <= limit, max(0, limit - count), max(0, int(expires_at - now))
 
     def stats(self) -> dict:
         with self._lock:
+            self._prune_expired(time.time())
             return {"backend": "memory", "active_clients": len(self._entries)}
 
 

--- a/backend/api/rate_limit_store.py
+++ b/backend/api/rate_limit_store.py
@@ -1,0 +1,95 @@
+"""Shared rate-limit backends.
+
+Redis is opt-in. The in-memory backend remains the default for local/single-process use.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from threading import Lock
+from typing import Protocol
+
+
+class RateLimitStore(Protocol):
+    """Minimal storage contract used by RateLimiter."""
+
+    def check(self, key: str, limit: int, window_seconds: int) -> tuple[bool, int, int]:
+        """Return allowed, remaining, and reset seconds."""
+
+    def stats(self) -> dict:
+        """Return storage metadata."""
+
+
+class InMemoryRateLimitStore:
+    """Thread-safe fixed-window store for a single process."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, tuple[int, float]] = {}
+        self._last_cleanup_at = 0.0
+        self._lock = Lock()
+
+    def check(self, key: str, limit: int, window_seconds: int) -> tuple[bool, int, int]:
+        with self._lock:
+            now = time.time()
+            if now - self._last_cleanup_at >= max(1.0, float(window_seconds)):
+                self._entries = {
+                    entry_key: entry
+                    for entry_key, entry in self._entries.items()
+                    if now - entry[1] < window_seconds
+                }
+                self._last_cleanup_at = now
+            count, window_start = self._entries.get(key, (0, now))
+            if now - window_start >= window_seconds:
+                count, window_start = 0, now
+            count += 1
+            self._entries[key] = (count, window_start)
+            return count <= limit, max(0, limit - count), max(0, int(window_start + window_seconds - now))
+
+    def stats(self) -> dict:
+        with self._lock:
+            return {"backend": "memory", "active_clients": len(self._entries)}
+
+
+class RedisRateLimitStore:
+    """Atomic fixed-window store backed by Redis for multi-worker deployments."""
+
+    _SCRIPT = """
+    local count = redis.call('INCR', KEYS[1])
+    if count == 1 then
+        redis.call('EXPIRE', KEYS[1], ARGV[1])
+    end
+    local ttl = redis.call('TTL', KEYS[1])
+    return {count, ttl}
+    """
+
+    def __init__(self, url: str, namespace: str = "sdm:rate-limit:") -> None:
+        if not url:
+            raise ValueError("Redis URL is required when rate-limit backend is redis")
+        try:
+            import redis
+        except ImportError as exc:
+            raise RuntimeError("Redis rate limiting requires the optional 'redis' package") from exc
+        self._client = redis.Redis.from_url(url, decode_responses=False)
+        self._client.ping()
+        self._script = self._client.register_script(self._SCRIPT)
+        self._namespace = namespace
+
+    def check(self, key: str, limit: int, window_seconds: int) -> tuple[bool, int, int]:
+        values = self._script(keys=[f"{self._namespace}{key}"], args=[window_seconds])
+        count = int(values[0])
+        ttl = max(0, int(values[1]))
+        return count <= limit, max(0, limit - count), ttl
+
+    def stats(self) -> dict:
+        return {"backend": "redis", "namespace": self._namespace}
+
+
+def create_rate_limit_store() -> RateLimitStore:
+    """Create the configured store; never silently downgrade Redis to memory."""
+    backend = os.getenv("SDM_RATE_LIMIT_BACKEND", "memory").strip().lower()
+    if backend == "memory":
+        return InMemoryRateLimitStore()
+    if backend == "redis":
+        return RedisRateLimitStore(os.getenv("SDM_REDIS_URL", ""))
+    raise ValueError("Unsupported SDM_RATE_LIMIT_BACKEND; expected 'memory' or 'redis'")

--- a/backend/tests/test_rate_limit_store.py
+++ b/backend/tests/test_rate_limit_store.py
@@ -1,0 +1,77 @@
+import sys
+import types
+
+import pytest
+
+from backend.api.rate_limit_store import (
+    InMemoryRateLimitStore,
+    RedisRateLimitStore,
+    create_rate_limit_store,
+)
+
+
+def test_memory_store_enforces_limit_and_cleans_up():
+    store = InMemoryRateLimitStore()
+    clock = iter([100.0, 100.0, 161.0])
+    original_time = sys.modules["backend.api.rate_limit_store"].time.time
+    sys.modules["backend.api.rate_limit_store"].time.time = lambda: next(clock)
+    try:
+        assert store.check("old", 1, 60)[0] is True
+        assert store.stats()["active_clients"] == 1
+        assert store.check("new", 1, 60)[0] is True
+        assert store.stats()["active_clients"] == 1
+    finally:
+        sys.modules["backend.api.rate_limit_store"].time.time = original_time
+
+
+def test_store_selection(monkeypatch):
+    monkeypatch.setenv("SDM_RATE_LIMIT_BACKEND", "memory")
+    assert isinstance(create_rate_limit_store(), InMemoryRateLimitStore)
+    monkeypatch.setenv("SDM_RATE_LIMIT_BACKEND", "invalid")
+    with pytest.raises(ValueError, match="expected 'memory' or 'redis'"):
+        create_rate_limit_store()
+
+
+def test_redis_store_is_atomic_and_checks_connectivity(monkeypatch):
+    class FakeClient:
+        def ping(self):
+            return True
+
+        def register_script(self, script):
+            assert "INCR" in script
+            assert "EXPIRE" in script
+
+            def invoke(*, keys, args):
+                assert keys == ["sdm:rate-limit:client"]
+                assert args == [60]
+                return [2, 59]
+
+            return invoke
+
+    fake_redis = types.SimpleNamespace(
+        Redis=types.SimpleNamespace(from_url=lambda *args, **kwargs: FakeClient())
+    )
+    monkeypatch.setitem(sys.modules, "redis", fake_redis)
+    store = RedisRateLimitStore("redis://localhost/0")
+    allowed, remaining, reset = store.check("client", 3, 60)
+    assert (allowed, remaining, reset) == (True, 1, 59)
+
+
+def test_redis_store_fails_fast_when_unreachable(monkeypatch):
+    class FakeClient:
+        def ping(self):
+            raise ConnectionError("refused")
+
+    fake_redis = types.SimpleNamespace(
+        Redis=types.SimpleNamespace(from_url=lambda *args, **kwargs: FakeClient())
+    )
+    monkeypatch.setitem(sys.modules, "redis", fake_redis)
+    with pytest.raises(ConnectionError, match="refused"):
+        RedisRateLimitStore("redis://localhost/0")
+
+
+def test_redis_store_requires_url(monkeypatch):
+    monkeypatch.setenv("SDM_RATE_LIMIT_BACKEND", "redis")
+    monkeypatch.delenv("SDM_REDIS_URL", raising=False)
+    with pytest.raises(ValueError, match="Redis URL is required"):
+        create_rate_limit_store()

--- a/backend/tests/test_rate_limit_store.py
+++ b/backend/tests/test_rate_limit_store.py
@@ -12,7 +12,7 @@ from backend.api.rate_limit_store import (
 
 def test_memory_store_enforces_limit_and_cleans_up():
     store = InMemoryRateLimitStore()
-    clock = iter([100.0, 100.0, 161.0])
+    clock = iter([100.0, 100.0, 161.0, 161.0])
     original_time = sys.modules["backend.api.rate_limit_store"].time.time
     sys.modules["backend.api.rate_limit_store"].time.time = lambda: next(clock)
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ qa = [
     "bandit>=1.7",
     "pip-audit>=2.7",
 ]
+redis = [
+    "redis>=5.0.0",
+]
 
 [build-system]
 requires = ["setuptools>=75.0.0"]


### PR DESCRIPTION
P2 reliability hardening, isolated from the earlier discarded PR:

- Add an opt-in Redis-backed rate-limit store with atomic INCR/EXPIRE.
- Keep the in-memory store as the default for single-process deployments.
- Fail fast on Redis configuration/connectivity errors instead of silently degrading.
- Bound request bodies before application parsing, including chunked requests without Content-Length.
- Add regression tests for store behavior and cleanup.
