### PR TITLE
feat: separate liveness and readiness probes

### DIFF
--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -16,6 +16,7 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from .rate_limit_store import RateLimitStore, create_rate_limit_store
+from .readiness import readiness_response
 
 logger = logging.getLogger(__name__)
 DEFAULT_MAX_REQUEST_BODY_BYTES = 512 * 1024
@@ -92,9 +93,11 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         body_error = await self._read_bounded_body(request)
         if body_error is not None:
             return body_error
+        if request.url.path == "/ready" and request.method in {"GET", "HEAD"}:
+            return await readiness_response(request)
         if not self.enabled:
             return await call_next(request)
-        if request.url.path in ["/health", "/health/deep", "/ready", "/"] and request.method in {"GET", "HEAD"}:
+        if request.url.path in ["/health", "/health/deep", "/"] and request.method in {"GET", "HEAD"}:
             return await call_next(request)
 
         client_id = self._get_client_id(request)

--- a/backend/api/readiness.py
+++ b/backend/api/readiness.py
@@ -1,0 +1,79 @@
+"""Dependency-backed readiness probe for the API service."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+
+def _run_checks() -> dict[str, dict[str, Any]]:
+    """Run the lightweight-but-real component checks synchronously."""
+    from backend.api import main
+
+    checks: dict[str, dict[str, Any]] = {}
+
+    try:
+        result = main.transpiler.transpile("SELECT 1 AS readiness_probe", "mysql", "postgres")
+        checks["transpiler"] = {
+            "status": "ok" if result.success else "error",
+            "test_result": result.success,
+        }
+    except Exception as exc:
+        checks["transpiler"] = {"status": "error", "message": str(exc)}
+
+    try:
+        function = main.func_encyclopedia.get_function("CONCAT")
+        checks["functions"] = {
+            "status": "ok" if function else "error",
+            "sample_lookup": "CONCAT" if function else None,
+        }
+    except Exception as exc:
+        checks["functions"] = {"status": "error", "message": str(exc)}
+
+    try:
+        mapping = main.type_mapper.map_type("VARCHAR", "mysql", "postgres")
+        checks["types"] = {
+            "status": "ok" if mapping.get("success") else "error",
+            "sample_mapping": mapping.get("target_type"),
+        }
+    except Exception as exc:
+        checks["types"] = {"status": "error", "message": str(exc)}
+
+    try:
+        generated = main.nl2sql_generator.generate("查询所有用户", "mysql")
+        checks["nl2sql"] = {
+            "status": "ok" if generated.success else "error",
+            "confidence": generated.confidence,
+        }
+    except Exception as exc:
+        checks["nl2sql"] = {"status": "error", "message": str(exc)}
+
+    return checks
+
+
+async def readiness_response(request: Request) -> JSONResponse:
+    """Return HTTP 200 only when all core service probes pass."""
+    checks = await asyncio.to_thread(_run_checks)
+    failed = [name for name, check in checks.items() if check.get("status") != "ok"]
+    status = "ready" if not failed else "not_ready"
+    return JSONResponse(
+        status_code=200 if not failed else 503,
+        content={
+            "status": status,
+            "version": _api_version(),
+            "probe": "readiness",
+            "checks": checks,
+            "timestamp": datetime.now().isoformat(),
+        },
+    )
+
+
+def _api_version() -> str:
+    """Resolve API version lazily so probe imports do not create startup cycles."""
+    from backend.api import main
+
+    return main.API_VERSION

--- a/backend/tests/test_readiness_probe.py
+++ b/backend/tests/test_readiness_probe.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+
+from backend.api.main import app
+
+
+def test_readiness_probe_returns_dependency_status():
+    response = TestClient(app).get("/ready")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ready"
+    assert body["probe"] == "readiness"
+    assert all(check["status"] == "ok" for check in body["checks"].values())
+
+
+def test_readiness_probe_is_not_rate_limited():
+    client = TestClient(app)
+    for _ in range(105):
+        response = client.get("/ready")
+        assert response.status_code == 200


### PR DESCRIPTION
Add a dependency-backed /ready probe that bypasses request rate limiting, runs core service checks off the event loop, and returns 503 when readiness checks fail. Also add regression coverage.