### PR TITLE
fix: harden advanced SQL quoted literal boundaries

### DIFF
--- a/backend/core/audit_hardening.py
+++ b/backend/core/audit_hardening.py
@@ -1,6 +1,6 @@
 """Consolidated semantic and security hardening layer for SQL Dialect Master."""
 
-from typing import Callable, Optional
+from typing import Callable
 import logging
 import re
 
@@ -18,62 +18,144 @@ _ORIGINAL_PROCESS = PostProcessor.process
 
 
 def _scan_segments(sql: str):
-    i = 0; start = 0; n = len(sql)
+    """Split SQL into executable, quoted-literal, and comment segments."""
+    i = 0
+    start = 0
+    n = len(sql)
     while i < n:
         ch = sql[i]
+
+        # PostgreSQL dollar-quoted strings: $$...$$ and $tag$...$tag$.
+        if ch == "$":
+            match = re.match(r"\$([A-Za-z_][A-Za-z0-9_]*)?\$", sql[i:])
+            if match:
+                delimiter = match.group(0)
+                if start < i:
+                    yield "code", sql[start:i]
+                qstart = i
+                end = sql.find(delimiter, i + len(delimiter))
+                i = n if end < 0 else end + len(delimiter)
+                yield "quoted", sql[qstart:i]
+                start = i
+                continue
+
+        # Oracle q-quoted literals: q'[...']', q'{...}', q'(...)', q'<...>', q'|...|'.
+        if ch in "qQ" and i + 2 < n and sql[i + 1] == "'":
+            opener = sql[i + 2]
+            closer = {"[": "]", "{": "}", "(": ")", "<": ">"}.get(opener, opener)
+            end = sql.find(f"{closer}'", i + 3)
+            if end >= 0:
+                if start < i:
+                    yield "code", sql[start:i]
+                end += 2
+                yield "quoted", sql[i:end]
+                i = end
+                start = i
+                continue
+
         if ch in ("'", '"', '`') or ch == '[':
-            if start < i: yield "code", sql[start:i]
-            quote = ']' if ch == '[' else ch; qstart = i; i += 1
+            if start < i:
+                yield "code", sql[start:i]
+            quote = ']' if ch == '[' else ch
+            qstart = i
+            i += 1
             while i < n:
-                if quote == "'" and sql[i] == '\\' and i + 1 < n: i += 2; continue
+                if quote == "'" and sql[i] == "\\" and i + 1 < n:
+                    i += 2
+                    continue
                 if sql[i] == quote:
-                    if i + 1 < n and sql[i + 1] == quote: i += 2; continue
-                    i += 1; break
+                    if i + 1 < n and sql[i + 1] == quote:
+                        i += 2
+                        continue
+                    i += 1
+                    break
                 i += 1
-            yield "quoted", sql[qstart:i]; start = i; continue
+            yield "quoted", sql[qstart:i]
+            start = i
+            continue
+
         if ch == '-' and i + 1 < n and sql[i + 1] == '-':
-            if start < i: yield "code", sql[start:i]
+            if start < i:
+                yield "code", sql[start:i]
             j = i + 2
-            while j < n and sql[j] not in '\r\n': j += 1
-            yield "comment", sql[i:j]; i = j; start = i; continue
+            while j < n and sql[j] not in "\r\n":
+                j += 1
+            yield "comment", sql[i:j]
+            i = j
+            start = i
+            continue
+
         if ch == '/' and i + 1 < n and sql[i + 1] == '*':
-            if start < i: yield "code", sql[start:i]
+            if start < i:
+                yield "code", sql[start:i]
             j = i + 2
-            while j + 1 < n and not (sql[j] == '*' and sql[j + 1] == '/'): j += 1
-            j = min(n, j + 2); yield "comment", sql[i:j]; i = j; start = i; continue
+            while j + 1 < n and not (sql[j] == '*' and sql[j + 1] == '/'):
+                j += 1
+            j = min(n, j + 2)
+            yield "comment", sql[i:j]
+            i = j
+            start = i
+            continue
+
         i += 1
-    if start < n: yield "code", sql[start:]
+
+    if start < n:
+        yield "code", sql[start:]
 
 
 def _mask_non_executable(sql: str) -> str:
-    return ''.join(text if kind == "code" else ''.join('\n' if c in '\r\n' else ' ' for c in text) for kind, text in _scan_segments(sql))
+    return ''.join(
+        text if kind == "code" else ''.join('\n' if c in '\r\n' else ' ' for c in text)
+        for kind, text in _scan_segments(sql)
+    )
 
 
 def _replace_outside(sql: str, pattern: re.Pattern, replacement: str | Callable[[re.Match], str]):
-    parts = []; count = 0
+    parts = []
+    count = 0
     for kind, text in _scan_segments(sql):
-        if kind == "code": text, changed = pattern.subn(replacement, text); count += changed
+        if kind == "code":
+            text, changed = pattern.subn(replacement, text)
+            count += changed
         parts.append(text)
     return ''.join(parts), count
 
 
 def _top_level_keyword(text: str, keyword: str) -> int:
-    wanted = keyword.upper(); depth = 0; quote = None; i = 0
+    wanted = keyword.upper()
+    depth = 0
+    quote = None
+    i = 0
     while i < len(text):
         ch = text[i]
         if quote is not None:
             if ch == quote:
-                if i + 1 < len(text) and text[i + 1] == quote: i += 2; continue
+                if i + 1 < len(text) and text[i + 1] == quote:
+                    i += 2
+                    continue
                 quote = None
-            elif quote == "'" and ch == '\\' and i + 1 < len(text): i += 2; continue
-            i += 1; continue
-        if ch in ("'", '"', '`'): quote = ch; i += 1; continue
+            elif quote == "'" and ch == '\\' and i + 1 < len(text):
+                i += 2
+                continue
+            i += 1
+            continue
+        if ch in ("'", '"', '`'):
+            quote = ch
+            i += 1
+            continue
         if ch == '(':
-            depth += 1; i += 1; continue
-        if ch == ')': depth = max(0, depth - 1); i += 1; continue
+            depth += 1
+            i += 1
+            continue
+        if ch == ')':
+            depth = max(0, depth - 1)
+            i += 1
+            continue
         if depth == 0 and text[i:i + len(wanted)].upper() == wanted:
-            before = text[i - 1] if i else ' '; after = text[i + len(wanted)] if i + len(wanted) < len(text) else ' '
-            if not (before.isalnum() or before == '_') and not (after.isalnum() or after == '_'): return i
+            before = text[i - 1] if i else ' '
+            after = text[i + len(wanted)] if i + len(wanted) < len(text) else ' '
+            if not (before.isalnum() or before == '_') and not (after.isalnum() or after == '_'):
+                return i
         i += 1
     return -1
 
@@ -89,57 +171,77 @@ def _dml_without_where(sql: str):
         if tree is None:
             continue
         for node in tree.walk():
-            if isinstance(node, exp.Update) and node.args.get("where") is None: result.append("UPDATE")
-            elif isinstance(node, exp.Delete) and node.args.get("where") is None: result.append("DELETE")
+            if isinstance(node, exp.Update) and node.args.get("where") is None:
+                result.append("UPDATE")
+            elif isinstance(node, exp.Delete) and node.args.get("where") is None:
+                result.append("DELETE")
     return result
 
 
 def _validate_security(self, sql: str):
-    result = {"blocked": False, "reason": None, "warnings": []}; masked = _mask_non_executable(sql)
+    result = {"blocked": False, "reason": None, "warnings": []}
+    masked = _mask_non_executable(sql)
     try:
         if len(sqlglot.parse(sql)) > 1:
             message = "Multiple SQL statements detected"
-            if settings.security_block_dangerous: result["blocked"] = True; result["reason"] = message; return result
+            if settings.security_block_dangerous:
+                result["blocked"] = True
+                result["reason"] = message
+                return result
             result["warnings"].append(f"🔒 Security: {message}")
     except Exception as exc:
         logger.debug("Stacked-statement AST parse unavailable; using masked regex fallback: %s", exc)
     for pattern, message in DANGEROUS_SQL_PATTERNS:
         if pattern.search(masked):
-            if settings.security_block_dangerous: result["blocked"] = True; result["reason"] = message; return result
+            if settings.security_block_dangerous:
+                result["blocked"] = True
+                result["reason"] = message
+                return result
             result["warnings"].append(f"🔒 Security: {message}")
     dml_without_where = set(_dml_without_where(sql))
-    for op in sorted(dml_without_where): result["warnings"].append(f"⚠️ {op} without WHERE clause - may affect all rows")
+    for op in sorted(dml_without_where):
+        result["warnings"].append(f"⚠️ {op} without WHERE clause - may affect all rows")
     for pattern, message in WARNING_SQL_PATTERNS:
         if message in {
             "DELETE without WHERE clause - will affect all rows",
             "UPDATE without WHERE clause - will affect all rows",
         }:
             continue
-        if pattern.search(masked): result["warnings"].append(f"⚠️ {message}")
+        if pattern.search(masked):
+            result["warnings"].append(f"⚠️ {message}")
     return result
 
 SQLTranspiler._validate_security = _validate_security
 
 
 def _generate_warnings(self, sql: str, source: str, target: str):
-    masked = _mask_non_executable(sql).upper(); warnings = []
-    if "DROP TABLE" in masked or "TRUNCATE" in masked: warnings.append("⚠️ Dangerous operation detected: DROP/TRUNCATE")
-    for op in _dml_without_where(sql): warnings.append(f"⚠️ {op} without WHERE clause - will affect all rows")
-    if "SELECT *" in masked: warnings.append("💡 Consider specifying columns instead of SELECT *")
-    if "CROSS JOIN" in masked: warnings.append("💡 CROSS JOIN can produce large result sets")
-    if len(re.findall(r"\bJOIN\b", masked)) > 5: warnings.append("💡 Query has many JOINs - consider query optimization")
+    masked = _mask_non_executable(sql).upper()
+    warnings = []
+    if "DROP TABLE" in masked or "TRUNCATE" in masked:
+        warnings.append("⚠️ Dangerous operation detected: DROP/TRUNCATE")
+    for op in _dml_without_where(sql):
+        warnings.append(f"⚠️ {op} without WHERE clause - will affect all rows")
+    if "SELECT *" in masked:
+        warnings.append("💡 Consider specifying columns instead of SELECT *")
+    if "CROSS JOIN" in masked:
+        warnings.append("💡 CROSS JOIN can produce large result sets")
+    if len(re.findall(r"\bJOIN\b", masked)) > 5:
+        warnings.append("💡 Query has many JOINs - consider query optimization")
     return warnings
 
 SQLTranspiler._generate_warnings = _generate_warnings
 
 
 def _simple_rownum_transform(sql: str):
-    masked = _mask_non_executable(sql); upper = masked.upper()
-    if "ROWNUM" not in upper: return sql, None
+    masked = _mask_non_executable(sql)
+    upper = masked.upper()
+    if "ROWNUM" not in upper:
+        return sql, None
     if len(re.findall(r"\bSELECT\b", upper)) != 1 or any(token in upper for token in (" OR ", " UNION ", " INTERSECT ", " EXCEPT ", " ORDER BY ", " GROUP BY ", " HAVING ", " DISTINCT ")):
         return sql, "Skipped automatic ROWNUM conversion because query shape is not provably LIMIT-equivalent"
     match = re.search(r"\bROWNUM\s*<=\s*(\d+)\b", masked, re.IGNORECASE)
-    if not match: return sql, "Skipped automatic ROWNUM conversion because query shape is not provably LIMIT-equivalent"
+    if not match:
+        return sql, "Skipped automatic ROWNUM conversion because query shape is not provably LIMIT-equivalent"
     n = match.group(1)
     for pattern, replacement in [
         (re.compile(r"\s+AND\s+ROWNUM\s*<=\s*\d+\b", re.IGNORECASE), ""),
@@ -147,7 +249,8 @@ def _simple_rownum_transform(sql: str):
         (re.compile(r"\bWHERE\s+ROWNUM\s*<=\s*\d+\b", re.IGNORECASE), ""),
     ]:
         result, count = _replace_outside(sql, pattern, replacement)
-        if count: return result.rstrip(';').rstrip() + f" LIMIT {n}", f"Converted simple ROWNUM <= {n} to LIMIT {n}"
+        if count:
+            return result.rstrip(';').rstrip() + f" LIMIT {n}", f"Converted simple ROWNUM <= {n} to LIMIT {n}"
     return sql, "Skipped automatic ROWNUM conversion because predicate shape was not safely removable"
 
 
@@ -160,22 +263,36 @@ PostProcessor._convert_rownum_to_limit = _convert_rownum_to_limit
 
 
 def _group_concat(args: str, original: str) -> str:
-    sep_pos = _top_level_keyword(args, "SEPARATOR"); before_sep = args; separator = "','"
-    if sep_pos >= 0: before_sep = args[:sep_pos].rstrip(); separator = args[sep_pos + 9:].strip() or separator
-    order_pos = _top_level_keyword(before_sep, "ORDER BY"); expression = before_sep; order_by = None
-    if order_pos >= 0: expression = before_sep[:order_pos].rstrip(); order_by = before_sep[order_pos + 8:].strip()
+    sep_pos = _top_level_keyword(args, "SEPARATOR")
+    before_sep = args
+    separator = "','"
+    if sep_pos >= 0:
+        before_sep = args[:sep_pos].rstrip()
+        separator = args[sep_pos + 9:].strip() or separator
+    order_pos = _top_level_keyword(before_sep, "ORDER BY")
+    expression = before_sep
+    order_by = None
+    if order_pos >= 0:
+        expression = before_sep[:order_pos].rstrip()
+        order_by = before_sep[order_pos + 8:].strip()
     distinct = expression[:9].upper() == "DISTINCT "
-    if distinct: expression = expression[9:].strip()
-    if not expression: return original
+    if distinct:
+        expression = expression[9:].strip()
+    if not expression:
+        return original
     needs_parentheses = distinct or not re.fullmatch(r"[A-Za-z_][\w$.]*", expression)
     rendered_expression = f"({expression})" if needs_parentheses else expression
     result = f"STRING_AGG({'DISTINCT ' if distinct else ''}{rendered_expression}::TEXT, {separator}"
-    if order_by: result += f" ORDER BY {order_by}"
+    if order_by:
+        result += f" ORDER BY {order_by}"
     return result + ")"
 
 
 def _process(self, sql: str, source: str, target: str):
-    working = sql; notes = []; source_l = source.lower(); target_l = target.lower()
+    working = sql
+    notes = []
+    source_l = source.lower()
+    target_l = target.lower()
     if source_l == "oracle" and target_l in {"mysql", "postgres", "hive", "spark"} and "ROWNUM" in _mask_non_executable(working).upper():
         converted, note = _simple_rownum_transform(working)
         if note and converted != working:
@@ -185,7 +302,8 @@ def _process(self, sql: str, source: str, target: str):
             return result, notes + legacy_notes
         elif note:
             working, _ = _replace_outside(working, re.compile(r"\bROWNUM\b", re.IGNORECASE), "__SDM_ROWNUM_SENTINEL__")
-            notes.append(note); result, legacy_notes = _ORIGINAL_PROCESS(self, working, source, target)
+            notes.append(note)
+            result, legacy_notes = _ORIGINAL_PROCESS(self, working, source, target)
             return result.replace("__SDM_ROWNUM_SENTINEL__", "ROWNUM"), notes + legacy_notes
     if source_l == "mysql" and target_l == "postgres" and "GROUP_CONCAT" in _mask_non_executable(working).upper():
         working, count = _replace_outside(working, re.compile(r"\bGROUP_CONCAT\s*\(", re.IGNORECASE), "__SDM_GROUP_CONCAT__(")
@@ -198,9 +316,11 @@ PostProcessor.process = _process
 
 
 def _apply_rule(self, sql: str):
-    if not self.enabled: return sql, False
+    if not self.enabled:
+        return sql, False
     pattern = getattr(self, '_compiled_pattern', None) or re.compile(self.pattern, re.IGNORECASE)
-    self._compiled_pattern = pattern; result, count = _replace_outside(sql, pattern, self.replacement)
+    self._compiled_pattern = pattern
+    result, count = _replace_outside(sql, pattern, self.replacement)
     return result, count > 0
 
 TransformRule.apply = _apply_rule

--- a/backend/tests/test_audit_hardening.py
+++ b/backend/tests/test_audit_hardening.py
@@ -59,6 +59,40 @@ def test_security_ignores_strings_and_comments():
     assert result["warnings"] == []
 
 
+def test_security_ignores_postgres_dollar_quoted_strings():
+    result = SQLTranspiler()._validate_security(
+        "SELECT $$DROP TABLE users; OR 1=1 SLEEP(10)$$ AS body"
+    )
+    assert result["blocked"] is False
+    assert result["warnings"] == []
+
+
+def test_security_ignores_postgres_tagged_dollar_quoted_strings():
+    result = SQLTranspiler()._validate_security(
+        "SELECT $payload$UNION SELECT information_schema.tables$payload$ AS body"
+    )
+    assert result["blocked"] is False
+    assert result["warnings"] == []
+
+
+def test_security_ignores_oracle_q_quoted_strings():
+    result = SQLTranspiler()._validate_security(
+        "SELECT q'[DROP TABLE users; OR 1=1]' AS body"
+    )
+    assert result["blocked"] is False
+    assert result["warnings"] == []
+
+
+def test_dialect_rewrite_ignores_dollar_quoted_strings():
+    generator = NL2SQLGenerator()
+    adjusted = generator._apply_dialect_adjustments(
+        "SELECT $$CURRENT_DATE DATE_SUB(CURRENT_DATE, 7)$$, CURRENT_DATE",
+        "oracle",
+    )
+    assert "$$CURRENT_DATE DATE_SUB(CURRENT_DATE, 7)$$" in adjusted
+    assert "TRUNC(SYSDATE)" in adjusted
+
+
 def test_security_detects_update_without_where_using_ast():
     result = SQLTranspiler()._validate_security("UPDATE users SET name = 'x'")
     assert any("UPDATE without WHERE" in warning for warning in result["warnings"])


### PR DESCRIPTION
Extend the existing SQL segment scanner to recognize PostgreSQL dollar-quoted and Oracle q-quoted literals, preventing security warnings and dialect rewrites inside executable-looking string content.