### PR TITLE
refactor: centralize compatibility patch installation

### DIFF
--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -24,45 +24,10 @@ from .exceptions import (
     SecurityViolationError,
     ValidationError,
 )
+from .compatibility import install_compatibility_patches
 
-# Install the focused multi-condition enhancement after NL2SQLGenerator is loaded.
-from .nl2sql_components.boolean_conditions import extract_boolean_conditions
-
-_original_extract_conditions = NL2SQLGenerator._extract_conditions_enhanced
-
-
-def _extract_conditions_with_boolean(self, text, original):
-    boolean_conditions = extract_boolean_conditions(text)
-    if boolean_conditions:
-        return boolean_conditions
-    return _original_extract_conditions(self, text, original)
-
-
-NL2SQLGenerator._extract_conditions_enhanced = _extract_conditions_with_boolean
-
-# Install batch-size validation at the core boundary so oversized requests
-# cannot be silently truncated by the legacy batch implementations.
-from . import batch_validation  # noqa: F401,E402
-
-# Install core input validation so invalid direct callers receive the same
-# structured validation result as API callers.
-from . import input_validation  # noqa: F401,E402
-
-# Install the focused NULL-predicate precedence fix after NL2SQLGenerator is loaded.
-from . import nl2sql_null_predicate_fix  # noqa: F401,E402
-
-# Install the focused comparison precedence fix after the NULL-predicate fix.
-from . import nl2sql_comparison_precedence_fix  # noqa: F401,E402
-
-# Install the consolidated final hardening layer after all legacy compatibility patches.
-from . import final_hardening  # noqa: F401,E402
-
-# Install the audit boundary last: quote-aware rewrites, AST-first security,
-# conservative ROWNUM conversion, and semantic warning guards.
-from . import audit_hardening  # noqa: F401,E402
-
-# Install second-pass production guards after all compatibility patches.
-from . import production_hardening  # noqa: F401,E402
+# Legacy compatibility adapters are installed through one explicit, idempotent entry point.
+install_compatibility_patches()
 
 __all__ = [
     "setup_logging",
@@ -89,4 +54,5 @@ __all__ = [
     "ParseError",
     "SecurityViolationError",
     "ValidationError",
+    "install_compatibility_patches",
 ]

--- a/backend/core/compatibility.py
+++ b/backend/core/compatibility.py
@@ -1,0 +1,45 @@
+"""Explicit compatibility installation for remaining legacy hardening adapters."""
+
+from importlib import import_module
+
+_PATCH_MODULES = (
+    "batch_validation",
+    "input_validation",
+    "nl2sql_null_predicate_fix",
+    "nl2sql_comparison_precedence_fix",
+    "final_hardening",
+    "audit_hardening",
+    "production_hardening",
+)
+
+_installed = False
+
+
+def install_compatibility_patches() -> None:
+    """Install compatibility adapters once, in their required order."""
+    global _installed
+    if _installed:
+        return
+
+    from .nl2sql import NL2SQLGenerator
+    from .nl2sql_components.boolean_conditions import extract_boolean_conditions
+
+    if not getattr(NL2SQLGenerator, "_sdm_boolean_patch_installed", False):
+        original_extract = NL2SQLGenerator._extract_conditions_enhanced
+
+        def extract_conditions_with_boolean(self, text, original):
+            boolean_conditions = extract_boolean_conditions(text)
+            if boolean_conditions:
+                return boolean_conditions
+            return original_extract(self, text, original)
+
+        NL2SQLGenerator._extract_conditions_enhanced = extract_conditions_with_boolean
+        NL2SQLGenerator._sdm_boolean_patch_installed = True
+
+    for module_name in _PATCH_MODULES:
+        import_module(f".{module_name}", package=__package__)
+
+    _installed = True
+
+
+__all__ = ["install_compatibility_patches"]

--- a/backend/tests/test_compatibility_layer.py
+++ b/backend/tests/test_compatibility_layer.py
@@ -1,0 +1,14 @@
+from backend.core import install_compatibility_patches
+from backend.core.nl2sql import NL2SQLGenerator
+from backend.core.transpiler import SQLTranspiler
+
+
+def test_compatibility_install_is_idempotent():
+    install_compatibility_patches()
+    install_compatibility_patches()
+
+    result = SQLTranspiler().transpile("SELECT 1", "mysql", "postgres")
+    assert result.success
+
+    generated = NL2SQLGenerator().generate("find products with price greater than 10", "postgres")
+    assert generated.success


### PR DESCRIPTION
Clean reimplementation of the compatibility-layer refactor from the stable main baseline. Consolidates legacy hardening activation behind one explicit, idempotent installer without changing the existing hardening modules or config.