### PR TITLE
fix: validate runtime function and type data entries

### DIFF
--- a/backend/core/compatibility.py
+++ b/backend/core/compatibility.py
@@ -11,6 +11,7 @@ _PATCH_MODULES = (
     "audit_hardening",
     "production_hardening",
     "p1_hardening",
+    "p2_data_validation",
 )
 
 _installed = False

--- a/backend/core/p2_data_validation.py
+++ b/backend/core/p2_data_validation.py
@@ -1,0 +1,105 @@
+"""P2 runtime data validation adapters.
+
+Reject malformed individual function/type entries before they enter indexes or
+conversion logic. Kept as a compatibility adapter to avoid a larger refactor.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .config import FUNCTION_CATEGORIES, SUPPORTED_DIALECTS
+from .exceptions import ConfigurationError
+from .functions_lookup import FunctionEncyclopedia
+from .type_mapping import TypeMapper
+
+
+def _error(path: Path, message: str) -> ConfigurationError:
+    return ConfigurationError(
+        f"Invalid runtime data in {path}: {message}",
+        details={"data_path": str(path)},
+    )
+
+
+def _validate_function_entry(data_path: Path, index: int, entry: Any) -> None:
+    prefix = f"functions[{index}]"
+    if not isinstance(entry, dict):
+        raise _error(data_path, f"'{prefix}' must be an object")
+    name = entry.get("name")
+    category = entry.get("category")
+    dialects = entry.get("dialects")
+    if not isinstance(name, str) or not name.strip():
+        raise _error(data_path, f"'{prefix}.name' must be a non-empty string")
+    if not isinstance(category, str) or category.lower() not in FUNCTION_CATEGORIES:
+        raise _error(data_path, f"'{prefix}.category' must be a supported category")
+    if not isinstance(entry.get("description", ""), str) or not isinstance(entry.get("notes", ""), str):
+        raise _error(data_path, f"'{prefix}.description' and '{prefix}.notes' must be strings")
+    if not isinstance(dialects, dict):
+        raise _error(data_path, f"'{prefix}.dialects' must be an object")
+    unknown = sorted(set(dialects) - set(SUPPORTED_DIALECTS))
+    if unknown:
+        raise _error(data_path, f"'{prefix}.dialects' contains unsupported dialects: {unknown}")
+    if any(not isinstance(value, str) for value in dialects.values()):
+        raise _error(data_path, f"'{prefix}.dialects' values must be strings")
+
+    parameters = entry.get("parameters", [])
+    if not isinstance(parameters, list):
+        raise _error(data_path, f"'{prefix}.parameters' must be a list")
+    for pidx, parameter in enumerate(parameters):
+        if not isinstance(parameter, dict):
+            raise _error(data_path, f"'{prefix}.parameters[{pidx}]' must be an object")
+        for key in ("name", "type", "description"):
+            if not isinstance(parameter.get(key), str):
+                raise _error(data_path, f"'{prefix}.parameters[{pidx}].{key}' must be a string")
+        if not isinstance(parameter.get("required"), bool):
+            raise _error(data_path, f"'{prefix}.parameters[{pidx}].required' must be boolean")
+
+    examples = entry.get("examples", {})
+    if not isinstance(examples, dict) or any(
+        not isinstance(k, str) or not isinstance(v, str) for k, v in examples.items()
+    ):
+        raise _error(data_path, f"'{prefix}.examples' must map strings to strings")
+
+
+def _validate_type_mapping_entry(data_path: Path, name: Any, entry: Any) -> None:
+    if not isinstance(name, str) or not name.strip():
+        raise _error(data_path, "mapping keys must be non-empty strings")
+    if not isinstance(entry, dict):
+        raise _error(data_path, f"mappings[{name!r}] must be an object")
+    unknown = sorted(set(entry) - (set(SUPPORTED_DIALECTS) | {"notes"}))
+    if unknown:
+        raise _error(data_path, f"mappings[{name!r}] contains unsupported keys: {unknown}")
+    for dialect, value in entry.items():
+        if dialect == "notes":
+            if not isinstance(value, str):
+                raise _error(data_path, f"mappings[{name!r}].notes must be a string")
+        elif not isinstance(value, str) or not value.strip():
+            raise _error(data_path, f"mappings[{name!r}].{dialect} must be a non-empty string")
+
+
+def _validate_functions_init(self, *args, **kwargs):
+    _ORIGINAL_FUNCTIONS_INIT(self, *args, **kwargs)
+    for index, entry in enumerate(self.functions):
+        _validate_function_entry(self.data_path, index, entry)
+
+
+def _validate_types_init(self, *args, **kwargs):
+    _ORIGINAL_TYPES_INIT(self, *args, **kwargs)
+    for name, entry in self.mappings.items():
+        _validate_type_mapping_entry(self.data_path, name, entry)
+    for name, warning in self.precision_warnings.items():
+        if not isinstance(name, str) or not name.strip() or not isinstance(warning, str):
+            raise _error(self.data_path, "precision_warnings must map non-empty strings to strings")
+
+
+_ORIGINAL_FUNCTIONS_INIT = FunctionEncyclopedia.__init__
+_ORIGINAL_TYPES_INIT = TypeMapper.__init__
+
+if not getattr(FunctionEncyclopedia, "_sdm_p2_schema_patch", False):
+    FunctionEncyclopedia.__init__ = _validate_functions_init
+    FunctionEncyclopedia._sdm_p2_schema_patch = True
+
+if not getattr(TypeMapper, "_sdm_p2_schema_patch", False):
+    TypeMapper.__init__ = _validate_types_init
+    TypeMapper._sdm_p2_schema_patch = True

--- a/backend/tests/test_p2_data_validation.py
+++ b/backend/tests/test_p2_data_validation.py
@@ -1,0 +1,53 @@
+import json
+
+import pytest
+
+from backend.core.exceptions import ConfigurationError, ErrorCode
+from backend.core.functions_lookup import FunctionEncyclopedia
+from backend.core.type_mapping import TypeMapper
+
+
+def valid_function():
+    return {
+        "name": "COUNT",
+        "category": "aggregate",
+        "description": "Count rows",
+        "parameters": [{"name": "expr", "type": "expression", "required": True, "description": "Value"}],
+        "dialects": {"postgres": "COUNT(expr)"},
+        "examples": {"postgres": "SELECT COUNT(*)"},
+        "notes": "",
+    }
+
+
+@pytest.mark.parametrize("entry, needle", [
+    ({}, "name"),
+    ({"name": "COUNT", "category": "bad", "dialects": {}}, "category"),
+    ({"name": "COUNT", "category": "aggregate", "dialects": {"nope": "COUNT(x)"}}, "unsupported dialects"),
+    ({**valid_function(), "parameters": [{"name": "x", "type": "x", "required": "yes", "description": "x"}]}, "required.*must be boolean"),
+])
+def test_invalid_function_entry_schema(tmp_path, entry, needle):
+    path = tmp_path / "functions.json"
+    path.write_text(json.dumps({"functions": [entry]}), encoding="utf-8")
+    with pytest.raises(ConfigurationError, match=needle) as exc_info:
+        FunctionEncyclopedia(data_path=path)
+    assert exc_info.value.error_code == ErrorCode.CONFIGURATION_INVALID
+
+
+def test_valid_function_entry_loads(tmp_path):
+    path = tmp_path / "functions.json"
+    path.write_text(json.dumps({"functions": [valid_function()]}), encoding="utf-8")
+    assert FunctionEncyclopedia(data_path=path).get_function("COUNT")["name"] == "COUNT"
+
+
+@pytest.mark.parametrize("payload, needle", [
+    ({"mappings": {"INTEGER": "INT"}, "precision_warnings": {}}, "must be an object"),
+    ({"mappings": {"INTEGER": {"nope": "INT"}}, "precision_warnings": {}}, "unsupported keys"),
+    ({"mappings": {"INTEGER": {"postgres": 123}}, "precision_warnings": {}}, "must be a non-empty string"),
+    ({"mappings": {"INTEGER": {"postgres": "INT"}}, "precision_warnings": {"INTEGER": 123}}, "precision_warnings must map"),
+])
+def test_invalid_type_mapping_entry_schema(tmp_path, payload, needle):
+    path = tmp_path / "type_mapping.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ConfigurationError, match=needle) as exc_info:
+        TypeMapper(data_path=path)
+    assert exc_info.value.error_code == ErrorCode.CONFIGURATION_INVALID


### PR DESCRIPTION
## P2 hardening

- Validate every function encyclopedia entry before indexing it.
- Validate function dialect keys and parameter/example field types.
- Validate every type mapping entry and precision warning value.
- Reject unknown mapping keys instead of allowing malformed runtime data to propagate into API behavior.
- Add regression coverage for malformed entry-level schemas.

This is intentionally isolated in the compatibility layer to keep the remediation low-risk.