### PR TITLE
fix: harden deep health response semantics

### DIFF
--- a/backend/core/compatibility.py
+++ b/backend/core/compatibility.py
@@ -12,6 +12,7 @@ _PATCH_MODULES = (
     "production_hardening",
     "p1_hardening",
     "p2_data_validation",
+    "p2_health_semantics",
 )
 
 _installed = False

--- a/backend/core/compatibility.py
+++ b/backend/core/compatibility.py
@@ -13,6 +13,7 @@ _PATCH_MODULES = (
     "p1_hardening",
     "p2_data_validation",
     "p2_health_semantics",
+    "p2_health_semantics_fix",
 )
 
 _installed = False

--- a/backend/core/p2_health_semantics.py
+++ b/backend/core/p2_health_semantics.py
@@ -1,0 +1,88 @@
+"""P2 health endpoint hardening adapters.
+
+Keep liveness and deep-health semantics explicit: deep probes never expose raw
+exception text to clients and report unhealthy dependency state with HTTP 503.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from fastapi.responses import Response
+
+from backend.api.main import app
+
+logger = logging.getLogger(__name__)
+
+
+_RAW_ERROR_KEYS = {"message", "detail", "exception", "traceback"}
+
+
+def _redact_health_payload(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted = {}
+        for key, item in value.items():
+            if key in _RAW_ERROR_KEYS and isinstance(item, str):
+                redacted[key] = "internal health check failure"
+            else:
+                redacted[key] = _redact_health_payload(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_health_payload(item) for item in value]
+    return value
+
+
+class DeepHealthSanitizationMiddleware:
+    """Sanitize deep-health error payloads and set correct HTTP status."""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") != "http" or scope.get("path") != "/health/deep":
+            await self.app(scope, receive, send)
+            return
+
+        captured = {}
+        body_chunks = []
+
+        async def capture_send(message):
+            if message["type"] == "http.response.start":
+                captured.update(message)
+                return
+            if message["type"] == "http.response.body":
+                body_chunks.append(message.get("body", b""))
+                if not message.get("more_body", False):
+                    body = b"".join(body_chunks)
+                    try:
+                        payload = json.loads(body.decode("utf-8"))
+                        payload = _redact_health_payload(payload)
+                        if payload.get("status") == "❌ unhealthy":
+                            captured["status"] = 503
+                        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+                    except (UnicodeDecodeError, json.JSONDecodeError, AttributeError):
+                        logger.warning("Unable to sanitize deep health response body")
+                    headers = [
+                        (key, value)
+                        for key, value in captured.get("headers", [])
+                        if key.lower() != b"content-length"
+                    ]
+                    headers.append((b"content-length", str(len(body)).encode("ascii")))
+                    captured["headers"] = headers
+                    await send({
+                        "type": "http.response.start",
+                        "status": captured.get("status", 200),
+                        "headers": headers,
+                    })
+                    await send({"type": "http.response.body", "body": body, "more_body": False})
+                return
+            await send(message)
+
+        await self.app(scope, receive, capture_send)
+
+
+if not getattr(app, "_sdm_p2_health_semantics", False):
+    app.add_middleware(DeepHealthSanitizationMiddleware)
+    app._sdm_p2_health_semantics = True

--- a/backend/core/p2_health_semantics.py
+++ b/backend/core/p2_health_semantics.py
@@ -1,7 +1,6 @@
 """P2 health endpoint hardening adapters.
 
-Keep liveness and deep-health semantics explicit: deep probes never expose raw
-exception text to clients and report unhealthy dependency state with HTTP 503.
+Sanitize deep-health error payloads and expose dependency failures as HTTP 503.
 """
 
 from __future__ import annotations
@@ -10,79 +9,52 @@ import json
 import logging
 from typing import Any
 
-from fastapi.responses import Response
+from fastapi.responses import JSONResponse
 
-from backend.api.main import app
+from backend.api.middleware import RateLimitMiddleware
 
 logger = logging.getLogger(__name__)
-
 
 _RAW_ERROR_KEYS = {"message", "detail", "exception", "traceback"}
 
 
 def _redact_health_payload(value: Any) -> Any:
     if isinstance(value, dict):
-        redacted = {}
-        for key, item in value.items():
-            if key in _RAW_ERROR_KEYS and isinstance(item, str):
-                redacted[key] = "internal health check failure"
-            else:
-                redacted[key] = _redact_health_payload(item)
-        return redacted
+        return {
+            key: (
+                "internal health check failure"
+                if key in _RAW_ERROR_KEYS and isinstance(item, str)
+                else _redact_health_payload(item)
+            )
+            for key, item in value.items()
+        }
     if isinstance(value, list):
         return [_redact_health_payload(item) for item in value]
     return value
 
 
-class DeepHealthSanitizationMiddleware:
-    """Sanitize deep-health error payloads and set correct HTTP status."""
-
-    def __init__(self, app):
-        self.app = app
-
-    async def __call__(self, scope, receive, send):
-        if scope.get("type") != "http" or scope.get("path") != "/health/deep":
-            await self.app(scope, receive, send)
-            return
-
-        captured = {}
-        body_chunks = []
-
-        async def capture_send(message):
-            if message["type"] == "http.response.start":
-                captured.update(message)
-                return
-            if message["type"] == "http.response.body":
-                body_chunks.append(message.get("body", b""))
-                if not message.get("more_body", False):
-                    body = b"".join(body_chunks)
-                    try:
-                        payload = json.loads(body.decode("utf-8"))
-                        payload = _redact_health_payload(payload)
-                        if payload.get("status") == "❌ unhealthy":
-                            captured["status"] = 503
-                        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-                    except (UnicodeDecodeError, json.JSONDecodeError, AttributeError):
-                        logger.warning("Unable to sanitize deep health response body")
-                    headers = [
-                        (key, value)
-                        for key, value in captured.get("headers", [])
-                        if key.lower() != b"content-length"
-                    ]
-                    headers.append((b"content-length", str(len(body)).encode("ascii")))
-                    captured["headers"] = headers
-                    await send({
-                        "type": "http.response.start",
-                        "status": captured.get("status", 200),
-                        "headers": headers,
-                    })
-                    await send({"type": "http.response.body", "body": body, "more_body": False})
-                return
-            await send(message)
-
-        await self.app(scope, receive, capture_send)
+_ORIGINAL_RATE_LIMIT_DISPATCH = RateLimitMiddleware.dispatch
 
 
-if not getattr(app, "_sdm_p2_health_semantics", False):
-    app.add_middleware(DeepHealthSanitizationMiddleware)
-    app._sdm_p2_health_semantics = True
+async def _harden_health_response(self, request, call_next):
+    response = await _ORIGINAL_RATE_LIMIT_DISPATCH(self, request, call_next)
+    if request.url.path != "/health/deep" or not response.media_type or "json" not in response.media_type:
+        return response
+
+    try:
+        raw_body = b"".join([chunk async for chunk in response.body_iterator])
+        payload = _redact_health_payload(json.loads(raw_body.decode("utf-8")))
+        status = 503 if payload.get("status") == "❌ unhealthy" else response.status_code
+        return JSONResponse(
+            status_code=status,
+            content=payload,
+            headers={key: value for key, value in response.headers.items() if key.lower() != "content-length"},
+        )
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError, TypeError):
+        logger.warning("Unable to sanitize deep health response")
+        return response
+
+
+if not getattr(RateLimitMiddleware, "_sdm_p2_health_semantics", False):
+    RateLimitMiddleware.dispatch = _harden_health_response
+    RateLimitMiddleware._sdm_p2_health_semantics = True

--- a/backend/core/p2_health_semantics_fix.py
+++ b/backend/core/p2_health_semantics_fix.py
@@ -1,0 +1,42 @@
+"""Compatibility fix for deep-health response sanitization."""
+from __future__ import annotations
+
+import json
+
+from fastapi.responses import JSONResponse
+
+from backend.api.middleware import RateLimitMiddleware
+
+_ORIGINAL_DISPATCH = RateLimitMiddleware.dispatch
+
+
+async def _dispatch(self, request, call_next):
+    response = await _ORIGINAL_DISPATCH(self, request, call_next)
+    if request.url.path != "/health/deep":
+        return response
+    try:
+        raw_body = b"".join([chunk async for chunk in response.body_iterator])
+        payload = json.loads(raw_body.decode("utf-8"))
+        if isinstance(payload, dict):
+            checks = payload.get("checks")
+            if isinstance(checks, dict):
+                for check in checks.values():
+                    if isinstance(check, dict) and "message" in check:
+                        check["message"] = "internal health check failure"
+            if payload.get("status") == "❌ unhealthy":
+                status = 503
+            else:
+                status = response.status_code
+            return JSONResponse(
+                status_code=status,
+                content=payload,
+                headers={key: value for key, value in response.headers.items() if key.lower() != "content-length"},
+            )
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError, TypeError):
+        return response
+    return response
+
+
+if not getattr(RateLimitMiddleware, "_sdm_p2_health_semantics_fix", False):
+    RateLimitMiddleware.dispatch = _dispatch
+    RateLimitMiddleware._sdm_p2_health_semantics_fix = True

--- a/backend/tests/test_health_semantics_p2.py
+++ b/backend/tests/test_health_semantics_p2.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+
+from backend.api.main import app
+
+
+def test_deep_health_sanitizes_internal_error_and_returns_503(monkeypatch):
+    from backend.api import main
+
+    def explode(*args, **kwargs):
+        raise RuntimeError("SECRET_DATABASE_PASSWORD=leak-me")
+
+    monkeypatch.setattr(main.transpiler, "transpile", explode)
+
+    response = TestClient(app).get("/health/deep")
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["status"] == "❌ unhealthy"
+    assert payload["checks"]["transpiler"]["message"] == "internal health check failure"
+    assert "SECRET_DATABASE_PASSWORD" not in response.text


### PR DESCRIPTION
## P2 hardening

- Redact raw internal exception/detail text from `/health/deep` responses.
- Return HTTP 503 when deep health reports an unhealthy dependency.
- Add regression coverage ensuring secrets/internal messages do not leak.

This is isolated in the compatibility layer and preserves the existing healthy response contract.