### PR TITLE
fix: close semantic validation and release safety gaps

### DIFF
--- a/.github/actions-lock.sha
+++ b/.github/actions-lock.sha
@@ -1,4 +1,4 @@
-actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
-actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
 github/codeql-action@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd
 pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     labels:
       - dependencies
       - python
+    ignore:
+      - dependency-name: "websockets"
+        versions:
+          - ">=17"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,40 @@ jobs:
               f"{len(functions.functions)} functions, {len(mappings.mappings)} type mappings"
           )
           PY
+
+  semantic-runtime:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sql_dialect_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres -d sql_dialect_test"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install locked semantic test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-lock.txt -r requirements-semantic-lock.txt
+          pip install -e "." --no-deps
+
+      - name: Run runtime semantic regression suite
+        env:
+          SDM_TEST_POSTGRES_DSN: postgresql://postgres:postgres@127.0.0.1:5432/sql_dialect_test
+        run: pytest backend/tests/test_runtime_semantics.py -q

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*.*.*'
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -20,6 +19,34 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
+
+      - name: Verify tag matches project version
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          python - <<'PY'
+          import re
+          import tomllib
+          from pathlib import Path
+          import os
+
+          tag = os.environ["RELEASE_TAG"]
+          if not re.fullmatch(r"v\d+\.\d+\.\d+", tag):
+              raise SystemExit(f"Unsupported release tag format: {tag}")
+
+          with Path("pyproject.toml").open("rb") as handle:
+              project = tomllib.load(handle)
+          project_version = project["project"]["version"]
+          tag_version = tag.removeprefix("v")
+
+          if project_version != tag_version:
+              raise SystemExit(
+                  "Release tag/version mismatch: "
+                  f"tag={tag_version}, pyproject.toml={project_version}"
+              )
+
+          print(f"Release version verified: {project_version}")
+          PY
 
       - name: Install build tooling
         run: python -m pip install --upgrade pip build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ All notable changes to SQL Dialect Master are documented here.
 - Added CODEOWNERS, pull request templates, and issue templates.
 - Added tag-driven GitHub Release automation.
 - Added a PyPI publishing workflow using GitHub Actions trusted publishing (OIDC).
+- Refreshed the immutable GitHub Actions SHA lockfile after Dependabot action upgrades.
+- Added a generic SQL parser fallback when target-dialect parsing is unavailable, with an explicit compatibility warning.
+- Added an AST-based semantic diff detector for structural conversion regressions.
+- Added PostgreSQL + DuckDB runtime semantic regression coverage and a dedicated CI gate.
+- Added locked semantic-test dependencies for DuckDB and Psycopg.
+
+### Fixed
+
+- Release automation now rejects Git tags that do not exactly match `pyproject.toml` project version.
+- Dependabot now ignores `websockets>=17`, which conflicts with the currently locked Streamlit dependency.
 
 ## [1.0.1] - 2026-09-08
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Enterprise-grade multi-database SQL conversion engine supporting 12 database dia
 | 🔄 **SQL Conversion** | Convert SQL between 12 database dialects with a complete 12 × 12 conversion matrix |
 | ✅ **Output Validation** | Validate converted SQL with target-dialect parsing plus safe generic-parser fallback |
 | 🧠 **Semantic Regression Coverage** | Preserve predicates, joins, grouping, ordering, limits, windows, and round-trip validity |
+| 🔍 **AST Semantic Diff** | Compare dialect-aware SQL ASTs to detect structural changes introduced by conversion |
+| 🗄️ **Runtime Semantic Tests** | Execute representative conversions against PostgreSQL and DuckDB and compare result sets |
 | 📚 **Function Encyclopedia** | 298 SQL functions with cross-database comparison |
 | 🗂️ **Type Mapping** | 36 data types × 12 databases matrix |
 | 💬 **NL2SQL** | Natural language to SQL (Chinese/English) |
@@ -48,6 +50,12 @@ For development and testing, install the optional development dependencies:
 
 ```bash
 python -m pip install -e ".[dev]"
+```
+
+For database-backed semantic tests:
+
+```bash
+python -m pip install -e ".[dev,semantic]"
 ```
 
 ### Run Streamlit UI (Recommended)
@@ -126,6 +134,7 @@ sql-dialect-master/
 │   │   ├── config.py            # Configuration management
 │   │   ├── transpiler.py        # SQL conversion engine
 │   │   ├── parser.py            # SQL parser
+│   │   ├── semantic_diff.py     # AST-based semantic difference detector
 │   │   ├── rules.py             # Transformation rules
 │   │   ├── post_processor.py    # Post-processing
 │   │   ├── nl2sql.py            # Natural language to SQL
@@ -183,6 +192,10 @@ The project maintains a 12 × 12 source-to-target dialect regression matrix, sem
 
 Converted SQL is validated after post-processing. Target-dialect parsing is preferred; when a target parser limitation prevents validation but the generic parser accepts the SQL, the result is retained with a compatibility warning. Only when both validations fail is the conversion reported as unsuccessful.
 
+The AST semantic diff utility canonicalizes source and target SQL through SQLGlot and reports structural changes such as different predicates or AST node shapes. It is a regression detector rather than a proof of runtime equivalence.
+
+The semantic CI gate executes representative conversions against PostgreSQL and DuckDB and compares the source and converted result sets. This provides runtime evidence for supported SQL subsets without claiming universal cross-database semantic equivalence.
+
 Security validation structurally detects stacked SQL statements using the parser when available, with configurable policy controlling whether dangerous input is blocked or only warned about.
 
 The async batch API bounds concurrent work and preserves input order. A reproducible transpiler benchmark is available under `backend/benchmarks/` and is intentionally kept outside CI performance assertions.
@@ -222,11 +235,15 @@ pytest
 # Run with coverage
 pytest --cov=backend
 
+# Run database-backed semantic tests
+python -m pip install -e ".[dev,semantic]"
+pytest backend/tests/test_runtime_semantics.py -q
+
 # Run the reproducible benchmark
 python backend/benchmarks/transpiler_benchmark.py
 ```
 
-CI runs the complete pytest suite and Python compilation checks on Python 3.11 and 3.12.
+CI runs the complete pytest suite and Python compilation checks on Python 3.11 and 3.12, plus a PostgreSQL + DuckDB runtime semantic gate on Python 3.12.
 
 ## 📄 License
 

--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -11,6 +11,7 @@ from .config import (
 )
 from .parser import SQLParser, ParseResult
 from .transpiler import SQLTranspiler, TranspileResult
+from .semantic_diff import SQLSemanticDiffer, SemanticDiff, diff_sql_ast
 from .post_processor import PostProcessor
 from .functions_lookup import FunctionEncyclopedia
 from .type_mapping import TypeMapper
@@ -42,6 +43,9 @@ __all__ = [
     "ParseResult",
     "SQLTranspiler",
     "TranspileResult",
+    "SQLSemanticDiffer",
+    "SemanticDiff",
+    "diff_sql_ast",
     "TTLCache",
     "PostProcessor",
     "FunctionEncyclopedia",

--- a/backend/core/semantic_diff.py
+++ b/backend/core/semantic_diff.py
@@ -1,0 +1,111 @@
+"""AST-based SQL semantic diff helpers.
+
+The differ deliberately compares SQLGlot's dialect-independent generated SQL and
+its AST node shape. It is a structural regression detector, not a proof of
+runtime equivalence across database engines.
+"""
+from collections import Counter
+from dataclasses import dataclass, field
+from difflib import unified_diff
+from typing import List, Optional
+
+import sqlglot
+from sqlglot import exp
+
+
+@dataclass
+class SemanticDiff:
+    """Structural comparison of two SQL statements."""
+
+    equivalent: bool
+    source_normalized: Optional[str]
+    target_normalized: Optional[str]
+    differences: List[str] = field(default_factory=list)
+    parse_error: Optional[str] = None
+
+
+def _parse_and_normalize(sql: str, dialect: str) -> exp.Expression:
+    if not isinstance(sql, str) or not sql.strip():
+        raise ValueError("SQL must be a non-empty string")
+    return sqlglot.parse_one(sql, read=dialect).transform(lambda node: node.copy())
+
+
+def _canonical_sql(tree: exp.Expression) -> str:
+    return tree.sql(dialect="", pretty=False).strip()
+
+
+def _node_counts(tree: exp.Expression) -> Counter[str]:
+    return Counter(type(node).__name__ for node in tree.walk())
+
+
+def diff_sql_ast(
+    source_sql: str,
+    target_sql: str,
+    source_dialect: str = "",
+    target_dialect: str = "",
+) -> SemanticDiff:
+    """Compare two SQL ASTs after parsing them in their native dialects.
+
+    Equality means SQLGlot produced the same dialect-independent canonical SQL
+    and the same AST node-type shape. A difference means the conversion should
+    be reviewed; it does not by itself prove the target query is wrong.
+    """
+    try:
+        source_tree = _parse_and_normalize(source_sql, source_dialect)
+        target_tree = _parse_and_normalize(target_sql, target_dialect)
+    except Exception as exc:
+        return SemanticDiff(
+            equivalent=False,
+            source_normalized=None,
+            target_normalized=None,
+            differences=["Unable to parse one or both SQL statements"],
+            parse_error=str(exc),
+        )
+
+    source_normalized = _canonical_sql(source_tree)
+    target_normalized = _canonical_sql(target_tree)
+    source_counts = _node_counts(source_tree)
+    target_counts = _node_counts(target_tree)
+
+    differences: List[str] = []
+    if source_normalized != target_normalized:
+        diff_lines = list(
+            unified_diff(
+                source_normalized.splitlines(),
+                target_normalized.splitlines(),
+                fromfile="source",
+                tofile="target",
+                lineterm="",
+            )
+        )
+        differences.append("Canonical AST SQL differs")
+        differences.extend(diff_lines[:20])
+
+    changed_nodes = sorted(set(source_counts) | set(target_counts))
+    for node_name in changed_nodes:
+        source_count = source_counts.get(node_name, 0)
+        target_count = target_counts.get(node_name, 0)
+        if source_count != target_count:
+            differences.append(
+                f"AST node count changed: {node_name} {source_count} -> {target_count}"
+            )
+
+    return SemanticDiff(
+        equivalent=not differences,
+        source_normalized=source_normalized,
+        target_normalized=target_normalized,
+        differences=differences,
+    )
+
+
+class SQLSemanticDiffer:
+    """Object-oriented facade for callers that prefer a reusable service."""
+
+    @staticmethod
+    def compare(
+        source_sql: str,
+        target_sql: str,
+        source_dialect: str = "",
+        target_dialect: str = "",
+    ) -> SemanticDiff:
+        return diff_sql_ast(source_sql, target_sql, source_dialect, target_dialect)

--- a/backend/core/transpiler.py
+++ b/backend/core/transpiler.py
@@ -178,12 +178,14 @@ class SQLTranspiler:
             warnings = security_warnings + self._generate_warnings(sql, source, target)
 
             if validate:
-                validation_warning = self._validate_output(final_sql, target)
+                validation_error, validation_warning = self._validate_output_detailed(final_sql, target)
                 if validation_warning:
-                    logger.error(f"Output SQL validation failed: {source} -> {target}: {validation_warning}")
+                    warnings.append(validation_warning)
+                if validation_error:
+                    logger.error(f"Output SQL validation failed: {source} -> {target}: {validation_error}")
                     return TranspileResult(
                         success=False, source_sql=sql, source_dialect=source, target_dialect=target,
-                        error=validation_warning, error_code=ErrorCode.VALIDATION_FAILED.value,
+                        error=validation_error, error_code=ErrorCode.VALIDATION_FAILED.value,
                         compatibility_notes=compat_notes, transformations=transformations, warnings=warnings
                     )
 
@@ -274,11 +276,31 @@ class SQLTranspiler:
         return warnings
 
     def _validate_output(self, sql: str, dialect: str) -> Optional[str]:
+        """Validate target SQL, preserving the original error-only interface."""
+        error, _ = self._validate_output_detailed(sql, dialect)
+        return error
+
+    def _validate_output_detailed(
+        self, sql: str, dialect: str
+    ) -> tuple[Optional[str], Optional[str]]:
+        """Validate target SQL with a generic-parser compatibility fallback."""
         try:
             sqlglot.parse_one(sql, read=dialect)
-            return None
+            return None, None
         except Exception as target_error:
-            return f"⚠️ Output SQL may have syntax issues: {str(target_error)[:100]}"
+            target_message = str(target_error)[:100]
+            try:
+                sqlglot.parse_one(sql)
+            except Exception:
+                return f"⚠️ Output SQL may have syntax issues: {target_message}", None
+
+            warning = (
+                "⚠️ Target dialect parser rejected the output, but the generic "
+                "SQL parser accepted it; retaining the conversion with a "
+                f"compatibility warning. Target parser error: {target_message}"
+            )
+            logger.warning("Generic parser fallback used for %s output: %s", dialect, target_message)
+            return None, warning
 
     def _validate_security(self, sql: str) -> Dict[str, Any]:
         result = {"blocked": False, "reason": None, "warnings": []}

--- a/backend/tests/test_parser_fallback.py
+++ b/backend/tests/test_parser_fallback.py
@@ -1,0 +1,40 @@
+import sqlglot
+
+from backend.core.transpiler import SQLTranspiler
+
+
+def test_validate_output_falls_back_to_generic_parser(monkeypatch):
+    transpiler = SQLTranspiler()
+    calls = []
+
+    def fake_parse_one(sql, read=None, **kwargs):
+        calls.append(read)
+        if read == "postgres":
+            raise ValueError("simulated target parser limitation")
+        return object()
+
+    monkeypatch.setattr(sqlglot, "parse_one", fake_parse_one)
+
+    error, warning = transpiler._validate_output_detailed(
+        "SELECT 1", "postgres"
+    )
+
+    assert error is None
+    assert warning is not None
+    assert "generic SQL parser accepted" in warning
+    assert calls == ["postgres", None]
+    assert transpiler._validate_output("SELECT 1", "postgres") is None
+
+
+def test_validate_output_fails_when_target_and_generic_parser_reject(monkeypatch):
+    transpiler = SQLTranspiler()
+
+    def always_fail(*args, **kwargs):
+        raise ValueError("invalid SQL")
+
+    monkeypatch.setattr(sqlglot, "parse_one", always_fail)
+
+    error, warning = transpiler._validate_output_detailed("SELECT FROM", "postgres")
+
+    assert error is not None
+    assert warning is None

--- a/backend/tests/test_runtime_semantics.py
+++ b/backend/tests/test_runtime_semantics.py
@@ -1,0 +1,157 @@
+import os
+
+import pytest
+
+from backend.core.semantic_diff import diff_sql_ast
+from backend.core.transpiler import SQLTranspiler
+
+
+duckdb = pytest.importorskip("duckdb")
+psycopg = pytest.importorskip("psycopg")
+
+
+POSTGRES_DSN = os.getenv(
+    "SDM_TEST_POSTGRES_DSN",
+    "postgresql://postgres:postgres@127.0.0.1:5432/sql_dialect_test",
+)
+
+
+def _normalize_rows(rows):
+    normalized = []
+    for row in rows:
+        normalized.append(
+            tuple(float(value) if hasattr(value, "as_integer_ratio") or value.__class__.__name__ == "Decimal" else value for value in row)
+        )
+    return normalized
+
+
+def _execute_duckdb(connection, sql):
+    return _normalize_rows(connection.execute(sql).fetchall())
+
+
+def _execute_postgres(connection, sql):
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+        return _normalize_rows(cursor.fetchall())
+
+
+def _prepare_duckdb(connection):
+    connection.execute("DROP TABLE IF EXISTS employees")
+    connection.execute(
+        """
+        CREATE TABLE employees (
+            id INTEGER,
+            department VARCHAR,
+            salary INTEGER,
+            active BOOLEAN
+        )
+        """
+    )
+    connection.executemany(
+        "INSERT INTO employees VALUES (?, ?, ?, ?)",
+        [
+            (1, "engineering", 100000, True),
+            (2, "engineering", 120000, True),
+            (3, "sales", 80000, True),
+            (4, "sales", 70000, False),
+        ],
+    )
+
+
+def _prepare_postgres(connection):
+    with connection.cursor() as cursor:
+        cursor.execute("DROP TABLE IF EXISTS employees")
+        cursor.execute(
+            """
+            CREATE TABLE employees (
+                id INTEGER,
+                department TEXT,
+                salary INTEGER,
+                active BOOLEAN
+            )
+            """
+        )
+        cursor.executemany(
+            "INSERT INTO employees VALUES (%s, %s, %s, %s)",
+            [
+                (1, "engineering", 100000, True),
+                (2, "engineering", 120000, True),
+                (3, "sales", 80000, True),
+                (4, "sales", 70000, False),
+            ],
+        )
+    connection.commit()
+
+
+@pytest.fixture(scope="module")
+def duckdb_connection():
+    connection = duckdb.connect(database=":memory:")
+    _prepare_duckdb(connection)
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+@pytest.fixture(scope="module")
+def postgres_connection():
+    try:
+        connection = psycopg.connect(POSTGRES_DSN)
+    except Exception as exc:
+        pytest.skip(f"PostgreSQL runtime test database unavailable: {exc}")
+
+    try:
+        _prepare_postgres(connection)
+        yield connection
+    finally:
+        connection.close()
+
+
+QUERY = """
+SELECT department, COUNT(*) AS employee_count, AVG(salary) AS avg_salary
+FROM employees
+WHERE active = TRUE
+GROUP BY department
+ORDER BY department
+"""
+
+
+@pytest.mark.parametrize(
+    ("source", "target", "source_sql", "target_engine"),
+    [
+        ("postgres", "duckdb", QUERY, "duckdb"),
+        ("duckdb", "postgres", QUERY, "postgres"),
+    ],
+)
+def test_transpiled_sql_matches_source_runtime(
+    source,
+    target,
+    source_sql,
+    target_engine,
+    duckdb_connection,
+    postgres_connection,
+):
+    transpiler = SQLTranspiler()
+    result = transpiler.transpile(source_sql, source, target, pretty=False, validate=True)
+    assert result.success, result.error
+    assert result.target_sql
+
+    semantic = diff_sql_ast(
+        source_sql,
+        result.target_sql,
+        source_dialect=source,
+        target_dialect=target,
+    )
+    assert semantic.equivalent, semantic.differences
+
+    if source == "postgres":
+        source_rows = _execute_postgres(postgres_connection, source_sql)
+    else:
+        source_rows = _execute_duckdb(duckdb_connection, source_sql)
+
+    if target_engine == "postgres":
+        target_rows = _execute_postgres(postgres_connection, result.target_sql)
+    else:
+        target_rows = _execute_duckdb(duckdb_connection, result.target_sql)
+
+    assert target_rows == source_rows

--- a/backend/tests/test_semantic_diff.py
+++ b/backend/tests/test_semantic_diff.py
@@ -1,0 +1,38 @@
+from backend.core.semantic_diff import SQLSemanticDiffer, diff_sql_ast
+
+
+def test_semantic_diff_accepts_equivalent_cross_dialect_sql():
+    result = diff_sql_ast(
+        "SELECT id FROM users WHERE age > 10",
+        "select id from users where age > 10",
+        source_dialect="postgres",
+        target_dialect="duckdb",
+    )
+
+    assert result.equivalent is True
+    assert result.differences == []
+
+
+def test_semantic_diff_detects_predicate_change():
+    result = SQLSemanticDiffer.compare(
+        "SELECT id FROM users WHERE age > 10",
+        "SELECT id FROM users WHERE age >= 10",
+        source_dialect="postgres",
+        target_dialect="duckdb",
+    )
+
+    assert result.equivalent is False
+    assert any("Canonical AST SQL differs" in item for item in result.differences)
+
+
+def test_semantic_diff_reports_parse_failure():
+    result = diff_sql_ast(
+        "SELECT id FROM users",
+        "SELECT FROM",
+        source_dialect="postgres",
+        target_dialect="duckdb",
+    )
+
+    assert result.equivalent is False
+    assert result.parse_error
+    assert result.differences == ["Unable to parse one or both SQL statements"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ qa = [
     "bandit>=1.7",
     "pip-audit>=2.7",
 ]
+semantic = [
+    "duckdb>=1.5.5",
+    "psycopg[binary]>=3.3.5",
+]
 redis = [
     "redis>=5.0.0",
 ]

--- a/requirements-semantic-lock.txt
+++ b/requirements-semantic-lock.txt
@@ -1,0 +1,2 @@
+duckdb==1.5.5
+psycopg[binary]==3.3.5


### PR DESCRIPTION
## Summary
- refresh `.github/actions-lock.sha` for checkout v7.0.1 and setup-python v7.0.0
- implement target-parser -> generic-parser validation fallback with an explicit compatibility warning
- reject release tags that do not match `pyproject.toml` project version
- ignore `websockets>=17` in Dependabot until the locked Streamlit constraint is compatible
- add AST-based SQL semantic diff utilities
- add PostgreSQL + DuckDB runtime semantic regression tests and a dedicated CI gate
- document the new validation coverage

## Validation
The PR adds regression tests for parser fallback, AST semantic diff, and cross-database runtime result equivalence. CI is expected to run the full suite on Python 3.11/3.12 plus the PostgreSQL + DuckDB semantic gate on Python 3.12.
