### PR TITLE
fix: harden NL2SQL regexes against ReDoS

### DIFF
--- a/backend/core/nl2sql_components/boolean_conditions.py
+++ b/backend/core/nl2sql_components/boolean_conditions.py
@@ -70,9 +70,8 @@ _SET_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-_CN_SET_PATTERN = re.compile(
-    r"(类别|类型|部门|地区|状态)\s*(不在|在)\s*([^且并或和()，,]+?(?:[，,]\s*[^且并或和()，,]+?)*)"
-    r"\s*(?:之中|其中|中)?(?=且|并且|或者|或|和|$)"
+_CN_SET_PREFIX_PATTERN = re.compile(
+    r"(类别|类型|部门|地区|状态)\s*(不在|在)\s*"
 )
 
 _STATUS_PATTERN = re.compile(
@@ -208,12 +207,23 @@ def _comparison_matches(text: str) -> List[Tuple[int, int, str]]:
             operator = "NOT IN" if negation else "IN"
             matches.append((match.start(), match.end(), f"{column.lower()} {operator} ({values})"))
 
-    for match in _CN_SET_PATTERN.finditer(text):
-        column, operator_text, raw_values = match.groups()
+    for match in _CN_SET_PREFIX_PATTERN.finditer(text):
+        column, operator_text = match.groups()
+        value_end = len(text)
+        connector = _CONNECTOR_PATTERN.search(text, match.end())
+        if connector is not None:
+            value_end = connector.start()
+        raw_values = text[match.end() : value_end].strip()
+        for suffix in ("之中", "其中", "中"):
+            if raw_values.endswith(suffix):
+                raw_values = raw_values[: -len(suffix)].rstrip()
+                break
+        if not raw_values or any(char in raw_values for char in "()"):
+            continue
         values = _format_set_values(raw_values)
         if values:
             operator = "NOT IN" if operator_text == "不在" else "IN"
-            matches.append((match.start(), match.end(), f"{_CN_SET_COLUMNS[column]} {operator} ({values})"))
+            matches.append((match.start(), value_end, f"{_CN_SET_COLUMNS[column]} {operator} ({values})"))
 
     for match in _STATUS_PATTERN.finditer(text):
         status = match.group(1).lower()

--- a/backend/core/nl2sql_components/templates.py
+++ b/backend/core/nl2sql_components/templates.py
@@ -28,6 +28,12 @@ _TEMPLATE_BLOCKERS = {
     "simple_select": _COMPOSITION_MARKERS,
 }
 
+# Keep template captures bounded. These patterns run against natural-language
+# query text, so unbounded adjacent wildcards can cause excessive backtracking
+# on adversarial input. 512 characters is ample for each individual template
+# field while making the regex work bounded by construction.
+_TEMPLATE_CAPTURE_LIMIT = 512
+
 
 @dataclass
 class QueryTemplate:
@@ -75,13 +81,13 @@ class QueryTemplate:
 DEFAULT_QUERY_TEMPLATES = [
     QueryTemplate(
         name="top_n_query",
-        pattern=r"(?:查询|获取|get|show|find)?\s*(?:前|top|bottom|最低|最少|lowest|smallest)\s*(\d+)\s*(?:个|条|名)?\s*(.+?)(?:按|by)?\s*(.+?)?\s*(?:排序|排列|order)?",
+        pattern=rf"(?:查询|获取|get|show|find)?\s*(?:前|top|bottom|最低|最少|lowest|smallest)\s*(\d+)\s*(?:个|条|名)?\s*(.{{1,{_TEMPLATE_CAPTURE_LIMIT}}}?)(?:按|by)?\s*(.{{1,{_TEMPLATE_CAPTURE_LIMIT}}})?\s*(?:排序|排列|order)?",
         sql_template="SELECT * FROM {table} ORDER BY {order_col} DESC LIMIT {n}",
         priority=90,
     ),
     QueryTemplate(
         name="count_by_group",
-        pattern=r"(?:统计|计算|count)\s*(?:每个|各个|each)?\s*(.+?)\s*(?:的|的数量|数量|有多少)",
+        pattern=rf"(?:统计|计算|count)\s*(?:每个|各个|each)?\s*(.{{1,{_TEMPLATE_CAPTURE_LIMIT}}}?)\s*(?:的|的数量|数量|有多少)",
         sql_template="SELECT {group_col}, COUNT(*) AS count FROM {table} GROUP BY {group_col}",
         priority=85,
     ),
@@ -93,25 +99,25 @@ DEFAULT_QUERY_TEMPLATES = [
     ),
     QueryTemplate(
         name="aggregate_query",
-        pattern=r"(?:计算|求|get)?\s*(.+?)\s*(?:的)?\s*(平均|总和|最大|最小|average|sum|max|min)\s*(.+)",
+        pattern=rf"(?:计算|求|get)?\s*(.{{1,{_TEMPLATE_CAPTURE_LIMIT}}}?)\s*(?:的)?\s*(平均|总和|最大|最小|average|sum|max|min)\s*(.{{1,{_TEMPLATE_CAPTURE_LIMIT}}})",
         sql_template="SELECT {agg_func}({col}) FROM {table}",
         priority=80,
     ),
     QueryTemplate(
         name="condition_query",
-        pattern=r"(?:查询|获取|find|get)?\s*(.+?)\s*(大于|小于|等于|超过|不等于|greater(?:\s+than)?|less(?:\s+than)?|equal(?:\s+to)?|>|<|=)\s*(\d+\.?\d*)\s*(?:的)?\s*(.+)?",
+        pattern=rf"(?:查询|获取|find|get)?\s*(.{{1,{_TEMPLATE_CAPTURE_LIMIT}}}?)\s*(大于|小于|等于|超过|不等于|greater(?:\s+than)?|less(?:\s+than)?|equal(?:\s+to)?|>|<|=)\s*(\d+\.?\d*)\s*(?:的)?\s*(.{{1,{_TEMPLATE_CAPTURE_LIMIT}}})?",
         sql_template="SELECT * FROM {table} WHERE {col} {op} {value}",
         priority=75,
     ),
     QueryTemplate(
         name="join_query",
-        pattern=r"(?:查询|获取)?\s*(.+?)\s*(?:和|与|关联|连接|join)\s*(.+?)(?:的|数据)?",
+        pattern=rf"(?:查询|获取)?\s*(.{{1,{_TEMPLATE_CAPTURE_LIMIT}}}?)\s*(?:和|与|关联|连接|join)\s*(.{{1,{_TEMPLATE_CAPTURE_LIMIT}}}?)(?:的|数据)?",
         sql_template="SELECT * FROM {table1} JOIN {table2} ON {join_condition}",
         priority=70,
     ),
     QueryTemplate(
         name="select_with_columns",
-        pattern=r"(?:查询|获取|显示|select|get|show)\s*(.+?)\s*(?:的|from)?\s*(.+?)(?:表|table)?$",
+        pattern=rf"(?:查询|获取|显示|select|get|show)\s*(.{{1,{_TEMPLATE_CAPTURE_LIMIT}}}?)\s*(?:的|from)?\s*(.{{1,{_TEMPLATE_CAPTURE_LIMIT}}}?)(?:表|table)?$",
         sql_template="SELECT {columns} FROM {table}",
         priority=60,
     ),

--- a/backend/tests/test_boolean_set_predicates.py
+++ b/backend/tests/test_boolean_set_predicates.py
@@ -1,9 +1,12 @@
 """AST regressions for IN / NOT IN boolean predicates."""
 
+import time
+
 import sqlglot
 from sqlglot import exp
 
 from backend.core.nl2sql import NL2SQLGenerator
+from backend.core.nl2sql_components.boolean_conditions import extract_boolean_conditions
 
 
 nl2sql = NL2SQLGenerator()
@@ -56,3 +59,15 @@ def test_chinese_not_in_predicate_is_preserved_with_comparison():
     assert isinstance(boolean.this.this.this, exp.In)
     assert isinstance(boolean.expression, exp.Paren)
     assert isinstance(boolean.expression.this, exp.GT)
+
+
+def test_chinese_set_predicate_handles_long_uncontrolled_value_linearly():
+    values = ",".join(f"value{i}" for i in range(5000))
+    text = f"查询类别在{values}中且价格大于100的产品"
+
+    started = time.monotonic()
+    conditions = extract_boolean_conditions(text)
+    elapsed = time.monotonic() - started
+
+    assert conditions
+    assert elapsed < 2.0

--- a/backend/tests/test_templates_redos.py
+++ b/backend/tests/test_templates_redos.py
@@ -1,0 +1,60 @@
+"""Regression tests for NL2SQL template regex hardening."""
+
+from backend.core.nl2sql_components.templates import (
+    DEFAULT_QUERY_TEMPLATES,
+    _TEMPLATE_CAPTURE_LIMIT,
+)
+
+
+def _templates_by_name():
+    return {template.name: template for template in DEFAULT_QUERY_TEMPLATES}
+
+
+def test_multi_segment_templates_use_bounded_captures():
+    templates = _templates_by_name()
+    hardened = (
+        "top_n_query",
+        "count_by_group",
+        "aggregate_query",
+        "condition_query",
+        "join_query",
+        "select_with_columns",
+    )
+
+    for name in hardened:
+        pattern = templates[name].pattern
+        assert f"{{1,{_TEMPLATE_CAPTURE_LIMIT}}}" in pattern
+        assert ".+?" not in pattern
+
+
+def test_hardened_templates_still_match_representative_queries():
+    templates = _templates_by_name()
+    cases = {
+        "top_n_query": "查询前10个客户 按销售额 排序",
+        "count_by_group": "统计每个部门的数量",
+        "aggregate_query": "计算订单的平均金额",
+        "condition_query": "查询年龄大于18的用户",
+        "join_query": "查询用户和订单的数据",
+        "select_with_columns": "查询姓名 年龄 用户表",
+    }
+
+    for name, text in cases.items():
+        assert templates[name].match(text) is not None, name
+
+
+def test_hardened_templates_bound_long_adversarial_input():
+    templates = _templates_by_name()
+    adversarial = "x" * (_TEMPLATE_CAPTURE_LIMIT * 4)
+
+    for name in (
+        "top_n_query",
+        "count_by_group",
+        "aggregate_query",
+        "condition_query",
+        "join_query",
+        "select_with_columns",
+    ):
+        # The match is intentionally exercised with input much larger than
+        # any individual capture so the regex cannot backtrack over an
+        # unbounded wildcard segment.
+        templates[name].match(adversarial)


### PR DESCRIPTION
## Summary
- replace the polynomial-risk boolean set regex with bounded structural parsing
- bound the six remaining multi-segment NL2SQL template captures
- add regression coverage for representative queries and adversarial long input

## Validation
CI and CodeQL should run on this pull request. This PR is intentionally left unmerged for verification of the security findings.