### PR TITLE
audit: establish architecture and semantic baseline

### DIFF
--- a/ARCHITECTURE_AUDIT.md
+++ b/ARCHITECTURE_AUDIT.md
@@ -1,0 +1,169 @@
+# Architecture Audit
+
+**Baseline commit:** `3f0bbd87e7c7d8ede8c72eb8b1604593c2f0c162`  
+**Audit branch:** `audit/architecture-baseline`  
+**Scope:** architecture, semantic pipeline, package topology, validation boundaries, production/API, CI and release path.  
+**Status:** audit only; no production implementation changes are included in PR 1.
+
+## 1. Executive assessment
+
+The repository has a substantial hardening foundation: 12 configured dialects, parser/transpiler/post-processing layers, quote/comment-aware scanners, security validation, runtime data validation, a 144-pair basic dialect matrix, PostgreSQL/DuckDB runtime evidence, pinned GitHub Actions, locked dependencies, wheel validation, and dedicated API/readiness tests.
+
+The main architectural risk has now shifted from missing safeguards to **semantic behavior being distributed across multiple compatibility/patch layers**. The conversion pipeline is therefore difficult to reason about as a compiler: the same conceptual rewrite can be defined in `rules.py`, overridden by `audit_hardening.py`, overridden again by `final_hardening.py`, and supplemented by `post_processor.py`.
+
+The most important architectural finding is that the repository has both a good scanner/structured-transformation foundation and a legacy global-regex rule model. The next work should consolidate these rather than add another compatibility layer.
+
+## 2. Current architecture
+
+```text
+                       +-----------------------+
+                       |   FastAPI / Streamlit |
+                       +-----------+-----------+
+                                   |
+                           boundary validation
+                                   |
+                 +-----------------+-----------------+
+                 |                                   |
+              SQL input                          NL input
+                 |                                   |
+          +------+-------+                    +------+-------+
+          | SQLTranspiler|                    |   NL2SQL     |
+          +------+-------+                    +------+-------+
+                 |                                   |
+          sqlglot parse/transpile             templates / extraction
+                 |                                   |
+          +------+-------+                    dialect adjustments
+          | PostProcessor|                           |
+          +------+-------+                           |
+                 |                          +--------+---------+
+          RuleEngine + custom               | generated SQL   |
+          transformations                   +--------+---------+
+                 |                                    |
+                 +----------------+-------------------+
+                                  |
+                           target SQL validation
+                                  |
+                    +-------------+--------------+
+                    |                            |
+              parser/AST evidence          runtime evidence
+                    |                            |
+              semantic diff                 DB execution
+```
+
+### Architectural observations
+
+1. `SQLTranspiler` owns orchestration, security checks, caching, output validation, warnings and batch execution.
+2. `PostProcessor` applies declarative rules followed by custom semantic rewrites.
+3. `p1_sql_scanner.py` and `function_call_scanner.py` provide the correct direction for lexical safety and nested-call handling.
+4. `parser.py` exposes an AST-oriented analysis API, but its metadata model is still shallow for compiler-grade semantic comparison.
+5. `semantic_diff.py` is currently a structural regression detector, not a complete semantic equivalence engine.
+6. `audit_hardening.py` and `final_hardening.py` monkey-patch runtime classes instead of expressing final behavior in the owning modules.
+
+## 3. Architectural strengths
+
+### Strong validation boundary
+The transpiler rejects multiple statements and validates target SQL after conversion. CI also exercises all configured dialect pairs at the parser-validity level.
+
+### Strong lexical safety primitives
+The scanner explicitly separates executable regions from literals, quoted identifiers and comments, including PostgreSQL dollar quoting and Oracle `q'...'` syntax. This is reusable compiler infrastructure and should become the mandatory boundary for remaining rewrites.
+
+### Strong packaging discipline
+The build configuration packages `backend*` and `frontend*`, excludes tests and benchmarks from distributions, and includes the JSON runtime data under `backend.core`.
+
+### Strong CI/release groundwork
+The CI workflow uses Python 3.11/3.12, runs the full suite, compiles sources, builds and inspects a wheel, smoke-tests installed runtime data, and has a dedicated PostgreSQL semantic-runtime gate. GitHub Actions are pinned by commit SHA.
+
+## 4. Major architectural risks
+
+### A1 — Multiple runtime monkey-patch layers (P0/P1 boundary)
+
+`audit_hardening.py` captures original methods and then assigns replacements onto `SQLTranspiler`, `PostProcessor`, `TransformRule` and `NL2SQLGenerator`. `final_hardening.py` then applies another set of replacements. This creates import-order and initialization-order coupling and makes the effective class implementation non-local.
+
+**Impact:** a code reviewer cannot inspect one owning module and know the effective semantics. Fixes can be accidentally shadowed by later compatibility imports.
+
+**Required direction:** fold stable behavior into the owning implementation, keep compatibility shims only where a public API needs them, and remove duplicate monkey patches after regression coverage exists.
+
+### A2 — Declarative RuleEngine still permits whole-SQL regex substitution
+
+`TransformRule.apply()` performs regex substitution against the entire SQL string. Some rules use patterns such as `([^\)]+)` or `([^,]+)` which cannot model arbitrary nested expressions.
+
+**Impact:** transformations can cross semantic boundaries even when the current scanner-backed compatibility path protects selected legacy handlers.
+
+**Required direction:** executable-region scanning first, then structured function/operator matching. Regex should be limited to lexical/token patterns whose grammar is explicitly bounded.
+
+### A3 — Semantic policy is split between sqlglot, RuleEngine and ad-hoc post-processing
+
+There is no single intermediate representation or semantic contract that says which transformation is syntax-only, which is structurally equivalent, and which requires an explicit warning.
+
+**Impact:** syntax-valid output can still be semantically wrong.
+
+**Required direction:** introduce a transformation classification and semantic evidence model before adding broad new rules.
+
+### A4 — NL2SQL dialect adjustment remains string-rewrite based
+
+NL2SQL initially generates common expressions such as `DATE_SUB(CURRENT_DATE, n)` and later applies target-dialect substitutions. The existence of multiple patches means dialect policy is not centralized in the SQL AST/generator layer.
+
+**Impact:** one template can be syntactically accepted in one target and semantically wrong in another, especially around dates, intervals and top-N behavior.
+
+**Required direction:** generate a dialect-neutral structured representation first, then render target-specific SQL; reserve textual rewrites for narrowly proven lexical cases.
+
+### A5 — Import/package topology is inconsistent
+
+`backend/api/main.py` mutates `sys.path` and then imports `core.*`, while other imports use `backend.*`. The package is configured as `backend*` and `frontend*`, so the path hack is not conceptually part of the packaging model.
+
+**Impact:** duplicate module identities such as `core.config` vs `backend.core.config` can create singleton/config/class identity surprises when different entrypoints import modules through different names.
+
+**Required direction:** standardize absolute imports on `backend.*` / `frontend.*` and remove runtime path mutation. Validate all supported entrypoints after migration.
+
+### A6 — Scanner logic is duplicated
+
+`audit_hardening.py` contains its own segment scanner while `p1_sql_scanner.py` is the intended shared scanner primitive.
+
+**Impact:** fixes to quoting/comment semantics can diverge between implementations.
+
+**Required direction:** make one scanner authoritative and delete the duplicate implementation once coverage is sufficient.
+
+## 5. API / production architecture observations
+
+The API stack already has CORS, security headers, rate limiting, structured logging, readiness/deep-health support, normalized dialect validation and centralized settings. This is a solid base.
+
+The next concern is less about adding middleware and more about ensuring lifecycle semantics are explicit: startup initialization, multi-worker behavior, shared probe state, dependency probe concurrency, request timeouts and proxy/header handling should have a single ownership model. Avoid depending on framework-private attributes.
+
+## 6. Compiler architecture target
+
+The desired end-state is:
+
+```text
+Raw input
+  -> lexical boundary analysis
+  -> dialect parse / NL semantic model
+  -> normalized IR / AST
+  -> semantic transformation passes
+  -> target dialect renderer
+  -> target parse
+  -> structural semantic checks
+  -> optional runtime evidence
+  -> result + warnings + provenance
+```
+
+Each transformation should declare:
+
+- source dialect / target dialect
+- input node or construct
+- semantic preconditions
+- output construct
+- confidence/evidence class
+- warning policy
+- regression tests
+
+## 7. Architecture decision
+
+PR 1 should not refactor the runtime. It establishes the baseline and creates the evidence required for the next PRs. PR 2 should fix the highest-confidence NL2SQL semantic bugs. PR 3/4 then make those fixes regression-resistant. Only after that should PR 5 consolidate RuleEngine semantics.
+
+## 8. Release blockers from architecture alone
+
+- Any known semantic rewrite that can silently produce a different query result.
+- Import topology that depends on `sys.path` mutation.
+- Multiple competing monkey-patch implementations of the same method.
+- A semantic-diff result being interpreted as proof of runtime equivalence.
+- Silent fallback from unknown/ambiguous type or function mapping.

--- a/SEMANTIC_RISK_REGISTER.md
+++ b/SEMANTIC_RISK_REGISTER.md
@@ -1,0 +1,81 @@
+# Semantic Risk Register
+
+**Baseline commit:** `3f0bbd87e7c7d8ede8c72eb8b1604593c2f0c162`  
+**Audit branch:** `audit/architecture-baseline`  
+**Method:** source inspection of conversion/NL2SQL/parser/diff/rule/test/CI layers.  
+**Policy:** no semantic risk is considered resolved merely because output parses.
+
+## Severity model
+
+- **P0:** high probability of semantic corruption or silent wrong-result SQL on common workloads; blocks semantic release confidence.
+- **P1:** architecture/testability risk that can cause or conceal semantic regressions, but is not itself proven to corrupt a common query class.
+- **P2:** maintainability, observability or performance debt without an immediate correctness impact.
+
+## P0 semantic risks
+
+| ID | Area | Risk | Likely failure mode | Required evidence |
+|---|---|---|---|---|
+| S-001 | NL2SQL dates | Generic `DATE_SUB(CURRENT_DATE, n)` template plus target-specific text rewrites do not establish semantics for every target dialect. | Target SQL is accepted but date arithmetic or interval typing differs. | Dialect-specific golden cases + target parser + runtime where available. |
+| S-002 | NL2SQL date rewrites | Multiple hardening modules redefine `_apply_dialect_adjustments`, including an implementation using raw `str.replace`/regex. | `CURRENT_DATE` or related text inside strings/comments can be rewritten; effective behavior depends on import order. | Literal/comment/string tests and import-order test. |
+| S-003 | ROWNUM/TOP/LIMIT | Row limiting constructs are not universally equivalent. ROWNUM filtering interacts with predicate/order shape; TOP can include dialect-specific options. | Different rows returned, especially with ordering, subqueries or additional predicates. | Semantic corpus for ordered/unordered cases; runtime evidence for supported DB pairs. |
+| S-004 | Aggregate rewrites | `GROUP_CONCAT`, `LISTAGG`, array aggregation and related conversions can lose order, NULL behavior, DISTINCT semantics or output typing. | Same syntax shape but different aggregate result. | Aggregate matrix with order, DISTINCT, NULL, empty-group cases. |
+| S-005 | NULL semantics | Function and predicate rewrites can confuse `IS NULL` predicates, two-argument null functions and type-dependent NULL behavior. | Different three-valued-logic result or coercion. | Truth-table fixtures and runtime checks. |
+| S-006 | Boolean precedence | Text/template transformations can alter grouping when `AND`/`OR` are combined. | Rows are included/excluded differently without a parse failure. | AST-based predicate comparison + runtime truth-table cases. |
+| S-007 | DML generation | INSERT/UPDATE/DELETE are less covered by the current semantic-runtime suite than SELECT aggregation. | Mutation affects different rows/columns or changes target behavior. | DML golden tests + runtime transaction-isolated fixtures. |
+
+## P1 semantic/validation risks
+
+| ID | Area | Risk | Why it matters |
+|---|---|---|---|
+| S-008 | Semantic diff | Current equality requires identical canonical SQL and identical AST node-type counts. | Semantically equivalent cross-dialect rewrites can be reported as different, while classifications beyond `equivalent=False` are unavailable. |
+| S-009 | Semantic diff | No distinction between `equivalent`, `structurally different but equivalent`, `potentially different`, and `definitely different`. | Callers cannot make policy decisions from the result. |
+| S-010 | Semantic diff | No first-class category/severity/source-fragment/target-fragment/explanation fields. | Reviewers cannot quickly understand whether a difference is harmless formatting or a dangerous semantic change. |
+| S-011 | Parser metadata | Function metadata sets `is_window` to `False` even when window expressions exist. | Downstream semantic analysis can undercount or misclassify window functions. |
+| S-012 | Type mapping | `map_type` falls back to partial substring matching and selects the first matching entry. | Ambiguous or parameterized type names can silently map to the wrong canonical type. |
+| S-013 | Function encyclopedia | Direct function lookup is exact-name based; aliases/normalized aliases and ambiguity policy are not first-class. | Unsupported or renamed functions can fail as a lookup miss or be handled inconsistently elsewhere. |
+| S-014 | RuleEngine | Many rules use regexes that do not model nested parentheses. | Nested function arguments can be truncated or incorrectly matched. |
+| S-015 | Rewrite boundaries | Scanner protection exists but is not universal across all compatibility layers. | A new rule can regress string/comment/identifier safety. |
+| S-016 | Evidence hierarchy | Target parse acceptance is still used as a practical gate even when semantic equivalence is unknown. | False confidence in conversion correctness. |
+
+## P2 semantic debt
+
+| ID | Area | Risk |
+|---|---|---|
+| S-017 | Duplicate scanner | `audit_hardening.py` duplicates scanner behavior that already exists in `p1_sql_scanner.py`. |
+| S-018 | Compatibility layers | Method monkey-patching makes semantic ownership non-local. |
+| S-019 | Test organization | Semantic tests are fragmented across many top-level test files rather than a dedicated corpus/matrix structure. |
+| S-020 | Corpus | There is no checked-in declarative Golden Corpus format containing semantic expectations and warning policies. |
+| S-021 | Runtime breadth | Runtime semantic evidence is concentrated on PostgreSQL/DuckDB and one main aggregation scenario. |
+
+## Dialect-specific review priorities
+
+### PostgreSQL
+Inspect interval/date arithmetic, `NULL`, casts, arrays/JSON and ordered aggregates.
+
+### MySQL
+Inspect `DATE_FORMAT`, `GROUP_CONCAT`, NULL functions, implicit coercion and LIMIT semantics.
+
+### Oracle
+Inspect `TRUNC`, `ADD_MONTHS`, `ROWNUM`, `FETCH`, empty-string/NULL behavior, `DECODE` and date types.
+
+### T-SQL
+Inspect `TOP`, `DATEADD`, `ISNULL`, `OFFSET/FETCH`, implicit conversions and window ordering.
+
+### DuckDB
+Use as a practical runtime oracle for portable analytical SQL, but do not treat it as proof of another engine's semantics.
+
+### Hive / Spark / Trino / Databricks
+Inspect array aggregations, distributed-engine-specific functions, interval syntax, collection functions and ordering guarantees.
+
+### Snowflake / Redshift / ClickHouse
+Prioritize type coercion, date functions, aggregation behavior and engine-specific function availability before claiming equivalence.
+
+## Hard semantic invariants for PR 2
+
+1. SQL literals, quoted identifiers and comments are immutable under rewrites.
+2. Parenthesis depth is preserved unless the transformation explicitly changes expression structure.
+3. Boolean precedence must be represented structurally, not inferred from string order.
+4. A top-N conversion must retain an equivalent ordering contract before claiming equivalence.
+5. Aggregate conversions must declare behavior for NULL, empty input, DISTINCT and ordering.
+6. Unknown or ambiguous dialect constructs must return explicit warnings/errors rather than silently guessing.
+7. Every semantic bug fixed becomes a permanent regression case.

--- a/TECH_DEBT_REPORT.md
+++ b/TECH_DEBT_REPORT.md
@@ -1,0 +1,139 @@
+# Technical Debt Report
+
+**Baseline commit:** `3f0bbd87e7c7d8ede8c72eb8b1604593c2f0c162`  
+**Audit branch:** `audit/architecture-baseline`  
+**Scope:** maintainability, architecture, dependency/build, testing organization, performance and release readiness.
+
+## Priority model
+
+- **P0:** blocks semantic confidence or can silently invalidate results.
+- **P1:** should be retired during the 1.1 engineering cycle.
+- **P2:** useful cleanup after correctness and reliability are established.
+
+## P1 maintainability debt
+
+### T-001 — Monkey-patch based compatibility architecture
+
+`audit_hardening.py` and `final_hardening.py` modify class methods after their classes are defined. This is difficult to reason about, especially when several compatibility modules target the same method.
+
+**Action:** move stable logic into `NL2SQLGenerator`, `PostProcessor`, `TransformRule` and `SQLTranspiler`; retain a compatibility wrapper only when external callers require a stable symbol.
+
+### T-002 — Duplicate scanner implementation
+
+`audit_hardening.py` contains `_scan_segments`, while `p1_sql_scanner.py` is a reusable scanner module.
+
+**Action:** establish `p1_sql_scanner.py` as the sole lexical boundary implementation and delete the duplicate after migration tests pass.
+
+### T-003 — Regex-heavy semantic transformations
+
+`rules.py` contains numerous regex transformations, including patterns whose captures stop at the first closing parenthesis.
+
+**Action:** classify rules into lexical-only versus expression-aware. Migrate expression-aware rules to scanner/AST transformations.
+
+### T-004 — Import topology
+
+The API entry point mutates `sys.path` and imports `core.*`, while the same application also imports `backend.*` modules.
+
+**Action:** standardize absolute package imports and add an import-topology regression test that imports every supported entrypoint under normal package execution.
+
+### T-005 — Fragmented semantic tests
+
+Semantic tests are currently spread across top-level files. This makes feature coverage difficult to inventory and allows related regressions to live in separate, implicit conventions.
+
+**Action:** introduce a dedicated semantic test package and corpus without deleting the historical regression cases until coverage is migrated.
+
+## P1 data-model debt
+
+### T-006 — Type mapping ambiguity
+
+The type mapper currently performs exact lookup and then partial substring matching. This is convenient but unsafe for parameterized or similarly named types.
+
+**Action:** exact → canonical alias → normalized alias → ambiguous result → unknown result. Never select the first partial match.
+
+### T-007 — Function alias model is implicit
+
+The encyclopedia has exact-name lookup and fuzzy search but no explicit alias/normalized-name model for semantic conversion.
+
+**Action:** add canonical function identity, aliases, supported/unsupported dialect metadata and explicit ambiguity handling.
+
+### T-008 — Semantic diff result model is underspecified
+
+`SemanticDiff` currently contains a Boolean `equivalent`, normalized SQL, free-form differences and parse error.
+
+**Action:** introduce structured difference records and equivalence classifications while preserving the existing facade for compatibility.
+
+## P2 maintainability debt
+
+### T-009 — Hard-coded counts in documentation/API metadata
+
+The project contains documentation and API descriptions that state counts such as 298 functions and 36 data types. These are vulnerable to drift when data files change.
+
+**Action:** source published metrics from loaded data or a verified generated metadata artifact.
+
+### T-010 — Test filename/layout drift
+
+Some semantic regressions use highly specific filenames while the project now needs a stable corpus-oriented taxonomy. `test_mysql_postgres.py` is currently an empty test module and should either become a real fixture family or be removed during intentional cleanup.
+
+### T-011 — Compatibility modules with unclear ownership
+
+Files named `p1_hardening.py`, `audit_hardening.py`, `production_hardening.py`, `final_hardening.py`, and related fixes indicate historical remediation layers rather than a single coherent architecture.
+
+**Action:** document ownership and dependencies first, then consolidate in incremental PRs. Do not perform a single large deletion/refactor.
+
+### T-012 — Warning policy is not fully structured
+
+Warnings are largely strings. Consumers cannot reliably distinguish semantic risk, unsupported feature, syntax compatibility fallback, precision loss and optimization advice.
+
+**Action:** define stable warning codes/severity/categories while retaining human-readable messages.
+
+## P2 performance/observability debt
+
+### T-013 — Benchmark data is not yet a semantic-quality metric
+
+A performance benchmark alone does not tell whether a fast conversion is correct.
+
+**Action:** benchmark per feature family and pair with semantic evidence counts.
+
+### T-014 — Timing is mostly request-level
+
+The API exposes process timing, but compiler-stage timings are not yet a clear observability contract.
+
+**Action:** later measure parser, transpile, rule processing, validation, semantic diff and cache stages independently.
+
+### T-015 — Runtime equivalence is database-limited
+
+Only engines actually available in CI can supply execution evidence.
+
+**Action:** keep runtime tests optional per engine, but make unsupported runtime coverage explicit in CI reports rather than silently treating it as equivalent.
+
+## P2 release debt
+
+### T-016 — Version remains 1.0.1
+
+`pyproject.toml` still declares version `1.0.1`. The 1.1.0 release must remain a later milestone after P0/P1 correctness work.
+
+### T-017 — Release gate needs semantic evidence
+
+The existing build/release path has strong package validation, but 1.1.0 should require the semantic corpus/matrix gates before publication.
+
+## Debt retirement order
+
+```text
+P0 semantic correctness
+  -> semantic corpus + matrix
+  -> safe RuleEngine
+  -> import architecture
+  -> semantic diff model
+  -> mapping/function data model
+  -> API production cleanup
+  -> performance/observability
+  -> release 1.1.0
+```
+
+## Anti-patterns explicitly prohibited
+
+- Adding another monkey-patch compatibility file for a new bug.
+- Adding another global `str.replace()` for SQL semantics.
+- Expanding partial-match lookup behavior to make a test pass.
+- Treating parser acceptance as proof of result equivalence.
+- Removing a failing regression test because the implementation is difficult to fix.

--- a/TEST_GAP_REPORT.md
+++ b/TEST_GAP_REPORT.md
@@ -1,0 +1,232 @@
+# Test Gap Report
+
+**Baseline commit:** `3f0bbd87e7c7d8ede8c72eb8b1604593c2f0c162`  
+**Audit branch:** `audit/architecture-baseline`  
+**Status:** inventory and gap analysis only; PR 1 does not alter test expectations or implementation.
+
+## 1. Current test inventory
+
+The repository already contains broad test families for API behavior, hardening, boolean semantics, cache, scanner safety, dialect conversion, NL2SQL semantics, parser fallback, post-processing, properties, runtime semantics, semantic diff, security statement boundaries, readiness and rate limiting.
+
+The current repository therefore has good breadth but the semantic tests are **fragmented** rather than organized around a single source-of-truth corpus.
+
+## 2. Existing matrix coverage
+
+`backend/tests/test_dialect_matrix.py` constructs:
+
+```python
+[(source, target) for source in SUPPORTED_DIALECTS for target in SUPPORTED_DIALECTS]
+```
+
+and therefore covers 12 × 12 = **144 conversion pairs** for one dialect-neutral SELECT. The test asserts conversion success and target parser acceptance. It explicitly documents that this is **not a semantic-equivalence claim**.
+
+Coverage classification:
+
+| Metric | Current state | Assessment |
+|---|---:|---|
+| Configured dialects | 12 | Good source of truth |
+| Basic source→target pairs | 144 / 144 | Good syntax gate |
+| Feature-level semantic matrix | Not established | Major gap |
+| Golden semantic corpus | Not established | Major gap |
+| AST semantic equivalence | Partial utility only | Major gap |
+| Runtime evidence | PostgreSQL ↔ DuckDB | Narrow |
+| DML runtime evidence | No comparable broad suite found | Gap |
+| Property-based tests | Present | Good foundation |
+| Literal/comment rewrite safety | Present for selected rules | Must become universal invariant |
+
+## 3. Runtime semantic coverage
+
+The current runtime semantic suite uses an in-memory DuckDB database and a PostgreSQL CI service. It exercises one employee aggregation query in both directions, checks AST semantic diff, and compares actual result rows.
+
+This is valuable evidence but it is not a broad runtime equivalence framework. In particular, it does not establish behavior for Oracle, T-SQL, MySQL, Hive/Spark-family engines, Trino, Snowflake, Redshift, ClickHouse or Databricks.
+
+## 4. Required target structure
+
+Create:
+
+```text
+backend/tests/semantic/
+├── corpus/
+│   ├── README.md
+│   └── *.json or *.yaml
+├── test_golden_sql.py
+├── test_dialect_matrix.py
+├── test_semantic_diff.py
+└── test_runtime_semantics.py
+```
+
+The existing top-level tests should remain during migration and be moved only when each case has an equivalent corpus representation; do not delete coverage merely to consolidate files.
+
+## 5. Golden Corpus schema
+
+Every corpus case should contain at least:
+
+```yaml
+id: mysql_group_concat_ordered
+source_dialect: mysql
+target_dialect: postgres
+feature: aggregate
+source_sql: "..."
+expected_sql: "..."          # optional for formatting-specific cases
+semantic_expectation: equivalent | warning | different
+expected_warning_codes: []
+notes: "..."
+```
+
+For semantic tests that cannot safely assert exact SQL, assert structured expectations instead:
+
+- predicate tree
+- projected columns
+- aggregation functions
+- group keys
+- order keys/directions
+- row-limit semantics
+- null predicates
+- casts/types
+- function identities
+
+## 6. P0 feature gaps
+
+### Dates/timestamps
+Add positive, negative and boundary cases for:
+
+- `DATE_SUB`
+- `DATE_ADD`
+- `ADD_MONTHS`
+- `CURRENT_DATE`
+- `CURRENT_TIMESTAMP`
+- month/year arithmetic
+- interval literals
+- timestamp/time-zone behavior
+- end-of-month behavior
+
+Targets: PostgreSQL, MySQL, Oracle, T-SQL, DuckDB plus at least parser-only coverage for other dialects.
+
+### NULL semantics
+Cover:
+
+- `IS NULL`
+- `IS NOT NULL`
+- `COALESCE`
+- MySQL `IFNULL`
+- Oracle `NVL`
+- T-SQL `ISNULL`
+- NULL inside aggregates
+- NULL comparison (`= NULL`, `<> NULL`) negative cases
+
+### Boolean precedence
+Cover nested combinations of `AND`, `OR`, `NOT`, predicates in function calls, parenthesized expressions, and generated NL2SQL conditions.
+
+### Top-N
+Cover:
+
+- `TOP n`
+- `TOP (n)`
+- `FETCH FIRST n ROWS ONLY`
+- `LIMIT n`
+- Oracle `ROWNUM`
+- explicit `ORDER BY`
+- no `ORDER BY`
+- `WITH TIES` / dialect-specific unsupported semantics
+- top-N inside subqueries
+
+### Aggregation
+Cover:
+
+- `COUNT(*)`
+- `COUNT(expr)`
+- `SUM`/`AVG` NULL behavior
+- `GROUP_CONCAT` / `STRING_AGG` / `LISTAGG`
+- DISTINCT aggregates
+- ordered aggregates
+- empty groups
+
+### DML
+Establish golden expectations for:
+
+- INSERT values
+- INSERT SELECT
+- UPDATE with predicates
+- DELETE with predicates
+- DML without WHERE as an explicit policy case
+- dialect-specific returning/output clauses
+
+## 7. Rule rewrite invariant tests
+
+Every rewrite rule must have:
+
+1. positive case
+2. negative/non-match case
+3. single-quoted literal case
+4. double/backtick/bracket identifier case where applicable
+5. line comment case
+6. block comment case
+7. nested function case
+8. nested parentheses case
+
+The existing quote-safety tests are a good seed, but they should be generated from rule metadata rather than maintained only for one example rule.
+
+## 8. Semantic-diff test gaps
+
+Current tests cover one clearly equivalent query, one changed predicate, and parse failure. The next corpus must add classification cases for:
+
+- formatting-only difference
+- identifier quoting difference
+- reordered commutative predicates
+- `AND`/`OR` precedence difference
+- NULL behavior difference
+- cast/type coercion difference
+- aggregate difference
+- order-by difference
+- limit/top difference
+- join condition difference
+- definitely incompatible syntax
+
+## 9. Property-based test targets
+
+Extend existing Hypothesis coverage to generate:
+
+- nested function expressions
+- nested boolean predicates
+- quoted identifiers
+- literals containing SQL-looking tokens
+- comments containing function names
+- arbitrary parenthesis depth within configured limits
+- combinations of NULL predicates and boolean operators
+
+Properties should include:
+
+- scanner does not modify protected regions
+- rewrite preserves balanced structure unless the rule explicitly changes it
+- target parse succeeds for cases classified as syntax-equivalent
+- no silent partial mapping occurs in type/function lookup
+
+## 10. Required CI evidence model
+
+CI should eventually publish counts for:
+
+```text
+syntax_pairs_tested
+ast_pairs_tested
+golden_cases_total
+golden_cases_passed
+runtime_cases_total
+runtime_cases_passed
+semantic_warnings
+unsupported_cases
+```
+
+A passing test suite must not hide unsupported dialect/feature cases. Unsupported semantics should appear as explicit, reviewable results.
+
+## 11. Release-quality test gate
+
+Before 1.1.0, the semantic gate should require:
+
+- all 144 basic pairs remain green
+- all P0 corpus cases green
+- no known P0 semantic warning downgraded to success without explicit evidence
+- semantic-diff classifications stable
+- runtime suites green where engines are available
+- no regression in scanner safety
+- property-based suite green
+- package/wheel smoke test green


### PR DESCRIPTION
## Summary

Establish the Phase 0 / PR 1 baseline for the 1.1 engineering plan without changing production behavior.

### Added
- `ARCHITECTURE_AUDIT.md`
- `SEMANTIC_RISK_REGISTER.md`
- `TEST_GAP_REPORT.md`
- `TECH_DEBT_REPORT.md`

### Key findings
- Existing 12-dialect / 144-pair matrix is a syntax-validity gate, not semantic equivalence proof.
- Runtime semantic evidence is currently concentrated on PostgreSQL ↔ DuckDB and a narrow aggregation scenario.
- `TransformRule` still contains a whole-SQL regex rewrite model even though scanner-backed infrastructure exists.
- `audit_hardening.py` and `final_hardening.py` introduce competing monkey-patch layers, including conflicting dialect adjustment implementations.
- `backend/api/main.py` still relies on `sys.path` mutation and `core.*` imports alongside `backend.*` imports.
- `TypeMapper` still has partial-match fallback; `SemanticDiff` still has a binary structural model.

### Scope discipline
This PR intentionally changes documentation only. No implementation or test behavior is modified.

### Next PR
`fix/nl2sql-dialect-semantics` should begin with failing regression tests for date arithmetic, NULL semantics, boolean precedence, top-N and aggregation before implementation changes.