### PR TITLE
P1: make RuleEngine rewrites structurally safe

### DIFF
--- a/backend/core/rules.py
+++ b/backend/core/rules.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Tuple
 
+from .p1_sql_scanner import executable_segments
+
 # Configure module logger
 logger = logging.getLogger(__name__)
 
@@ -61,7 +63,7 @@ class TransformRule:
         return source_match and target_match
     
     def apply(self, sql: str) -> Tuple[str, bool]:
-        """Apply this rule to SQL.
+        """Apply this rule only to executable SQL segments.
         
         Returns:
             Tuple of (transformed_sql, was_applied)
@@ -73,8 +75,20 @@ class TransformRule:
         if pattern is None:
             pattern = re.compile(self.pattern, re.IGNORECASE)
             self._compiled_pattern = pattern
-        new_sql, count = pattern.subn(self.replacement, sql)
-        return new_sql, count > 0
+
+        parts = []
+        cursor = 0
+        applied = False
+        for start, end in executable_segments(sql):
+            parts.append(sql[cursor:start])
+            segment = sql[start:end]
+            transformed, count = pattern.subn(self.replacement, segment)
+            parts.append(transformed)
+            applied = applied or count > 0
+            cursor = end
+
+        parts.append(sql[cursor:])
+        return "".join(parts), applied
 
 
 # =============================================================================
@@ -478,7 +492,7 @@ class RuleEngine:
         
         Args:
             name: Rule name to disable
-            
+        
         Returns:
             True if rule was found and disabled
         """
@@ -493,7 +507,7 @@ class RuleEngine:
         
         Args:
             name: Rule name to enable
-            
+        
         Returns:
             True if rule was found and enabled
         """

--- a/backend/tests/test_rule_engine_safe_rewrite.py
+++ b/backend/tests/test_rule_engine_safe_rewrite.py
@@ -1,0 +1,67 @@
+from backend.core.rules import RuleCategory, TransformRule
+
+
+def _rule() -> TransformRule:
+    return TransformRule(
+        name="test_ifnull",
+        source="mysql",
+        target="postgres",
+        pattern=r"IFNULL\s*\(([^,]+),\s*([^)]+)\)",
+        replacement=r"COALESCE(\1, \2)",
+        note="test",
+        category=RuleCategory.NULL_HANDLING,
+    )
+
+
+def test_transform_rule_does_not_rewrite_double_quoted_identifiers():
+    sql = 'SELECT "IFNULL(name, unknown)" AS identifier, IFNULL(name, unknown) AS value'
+    result, applied = _rule().apply(sql)
+
+    assert applied is True
+    assert '"IFNULL(name, unknown)"' in result
+    assert "COALESCE(name, unknown)" in result
+
+
+def test_transform_rule_does_not_rewrite_backtick_quoted_identifiers():
+    sql = "SELECT `IFNULL(name, unknown)` AS identifier, IFNULL(name, unknown) AS value"
+    result, applied = _rule().apply(sql)
+
+    assert applied is True
+    assert "`IFNULL(name, unknown)`" in result
+    assert "COALESCE(name, unknown)" in result
+
+
+def test_transform_rule_does_not_rewrite_bracket_quoted_identifiers():
+    sql = "SELECT [IFNULL(name, unknown)] AS identifier, IFNULL(name, unknown) AS value"
+    result, applied = _rule().apply(sql)
+
+    assert applied is True
+    assert "[IFNULL(name, unknown)]" in result
+    assert "COALESCE(name, unknown)" in result
+
+
+def test_transform_rule_does_not_rewrite_postgres_dollar_quoted_body():
+    sql = "SELECT $$IFNULL(name, unknown)$$ AS body, IFNULL(name, unknown) AS value"
+    result, applied = _rule().apply(sql)
+
+    assert applied is True
+    assert "$$IFNULL(name, unknown)$$" in result
+    assert "COALESCE(name, unknown)" in result
+
+
+def test_transform_rule_does_not_rewrite_inside_multiline_comment():
+    sql = "SELECT IFNULL(name, unknown) AS value /* IFNULL(fake, value) */"
+    result, applied = _rule().apply(sql)
+
+    assert applied is True
+    assert "COALESCE(name, unknown)" in result
+    assert "/* IFNULL(fake, value) */" in result
+
+
+def test_transform_rule_preserves_nested_argument_text_without_crossing_non_code():
+    sql = "SELECT IFNULL(name, unknown), 'IFNULL(fake, value)' FROM t"
+    result, applied = _rule().apply(sql)
+
+    assert applied is True
+    assert "COALESCE(name, unknown)" in result
+    assert "'IFNULL(fake, value)'" in result


### PR DESCRIPTION
## Goal
Make `TransformRule.apply()` safe for executable SQL only, without another hardening/monkey-patch layer.

## Scope
- Keep the public `TransformRule.apply(sql) -> (sql, applied)` and `RuleEngine` APIs compatible.
- Reuse `backend/core/p1_sql_scanner.py` to exclude string literals, quoted identifiers, and comments from regex rewrites.
- Preserve regex capture/replacement behavior and existing rule ordering.
- Add regression coverage for literals/comments, quoted identifiers, dollar-quoted bodies, and backslash-escaped string quotes where supported.
- Add a bounded/negative safety case for patterns using captures such as `([^)]+)` so nested syntax cannot be treated as arbitrary SQL text when the rule requires executable matching.
- Do not weaken existing tests or add a new hardening layer.

## Acceptance criteria
- Existing RuleEngine behavior tests remain green.
- New regressions fail before implementation and pass after implementation.
- No rewrites occur inside non-executable SQL segments.
- Existing executable rewrites still apply with the same notes/order.
- Full CI on Python 3.11/3.12, semantic-runtime, Quality, Benchmark, CodeQL, and README consistency are green.
- No unrelated production behavior changes.

## Out of scope
- NL2SQL changes
- Python import architecture refactor
- Parser/Semantic Diff redesign
- TypeMapper redesign
- API hardening

Follows the architecture audit and the completed semantic regression/conversion-matrix phases.