### PR TITLE
P1: unify Python package imports and remove runtime path hacks

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -9,10 +9,8 @@ Enterprise-grade multi-database SQL conversion API with:
 - Natural language to SQL generation
 """
 import logging
-import sys
 import time
 from datetime import datetime
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from fastapi import FastAPI, HTTPException, Query, Request
@@ -20,15 +18,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 
-# Add parent directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
-from core.config import get_dialect_api_info, settings, setup_logging
-from core.functions_lookup import FunctionEncyclopedia
-from core.nl2sql import NL2SQLGenerator
-from core.parser import SUPPORTED_DIALECTS, SQLParser
-from core.transpiler import SQLTranspiler
-from core.type_mapping import TypeMapper
+from backend.core.config import get_dialect_api_info, settings, setup_logging
+from backend.core.functions_lookup import FunctionEncyclopedia
+from backend.core.nl2sql import NL2SQLGenerator
+from backend.core.parser import SUPPORTED_DIALECTS, SQLParser
+from backend.core.transpiler import SQLTranspiler
+from backend.core.type_mapping import TypeMapper
 
 from backend.api.readiness import health_probe_response
 
@@ -597,7 +592,7 @@ async def health_check():
     return {
         "status": "alive",
         "version": API_VERSION,
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": datetime.now().isoformat()
     }
 
 @app.get("/ready", tags=["system"])

--- a/backend/api/readiness.py
+++ b/backend/api/readiness.py
@@ -173,6 +173,6 @@ async def deep_health_response(request: Request) -> JSONResponse:
 
 def _api_version() -> str:
     """Resolve API version without importing the API module back into readiness."""
-    from core.config import settings
+    from backend.core.config import settings
 
     return settings.api_version

--- a/backend/tests/test_import_architecture.py
+++ b/backend/tests/test_import_architecture.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYTHON_ROOTS = (REPO_ROOT / "backend", REPO_ROOT / "examples", REPO_ROOT / "scripts", REPO_ROOT)
+
+
+def _python_files():
+    seen = set()
+    for root in PYTHON_ROOTS:
+        if root.is_file() and root.suffix == ".py":
+            candidates = [root]
+        else:
+            candidates = root.rglob("*.py")
+        for path in candidates:
+            if path not in seen and ".git" not in path.parts:
+                seen.add(path)
+                yield path
+
+
+def test_runtime_python_does_not_mutate_sys_path():
+    forbidden = ("sys.path.insert(", "sys.path.append(", "sys.path +=")
+    offenders = []
+    for path in _python_files():
+        text = path.read_text(encoding="utf-8")
+        if any(token in text for token in forbidden):
+            offenders.append(str(path.relative_to(REPO_ROOT)))
+    assert offenders == []
+
+
+def test_runtime_python_does_not_import_legacy_core_namespace():
+    offenders = []
+    prefixes = ("from core.", "import core.")
+    for path in _python_files():
+        text = path.read_text(encoding="utf-8")
+        if any(line.lstrip().startswith(prefixes) for line in text.splitlines()):
+            offenders.append(str(path.relative_to(REPO_ROOT)))
+    assert offenders == []
+
+
+def test_backend_core_is_the_single_canonical_namespace():
+    import backend.core.config as backend_config
+
+    assert backend_config.__name__ == "backend.core.config"
+    assert backend_config.__package__ == "backend.core"
+
+    try:
+        import core.config as legacy_config  # noqa: F401
+    except ModuleNotFoundError:
+        return
+
+    assert legacy_config.__name__ != backend_config.__name__, (
+        "The legacy core namespace must not alias the canonical backend.core module"
+    )
+
+    assert legacy_config.__file__ != backend_config.__file__, (
+        "The same source file must never be loaded under both core.* and backend.core.*"
+    )

--- a/backend/tests/test_import_architecture.py
+++ b/backend/tests/test_import_architecture.py
@@ -2,12 +2,12 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-PYTHON_ROOTS = (REPO_ROOT / "backend", REPO_ROOT / "examples", REPO_ROOT / "scripts", REPO_ROOT)
+RUNTIME_ROOTS = (REPO_ROOT / "backend" / "api", REPO_ROOT / "backend" / "core", REPO_ROOT / "examples", REPO_ROOT / "scripts", REPO_ROOT / "frontend")
 
 
 def _python_files():
     seen = set()
-    for root in PYTHON_ROOTS:
+    for root in RUNTIME_ROOTS:
         if root.is_file() and root.suffix == ".py":
             candidates = [root]
         else:

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 """Basic usage examples for SQL Dialect Master."""
-import sys
-sys.path.insert(0, '..')
 
 from backend.core import SQLTranspiler, NL2SQLGenerator, FunctionEncyclopedia, TypeMapper
 

--- a/frontend/components.py
+++ b/frontend/components.py
@@ -3,12 +3,7 @@
 
 Provides helper functions to render common UI elements consistently.
 """
-import sys
-from pathlib import Path
 from typing import Dict
-
-# Add parent to path for backend imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from backend.core.config import DIALECT_METADATA
 


### PR DESCRIPTION
## Goal
Make the Python package topology deterministic and production-safe.

## Scope
- Remove runtime `sys.path` mutation.
- Replace legacy `core.*` imports with `backend.core.*` where required.
- Preserve public APIs and module behavior.
- Verify installed-package imports work without repository-root assumptions.
- Add regression coverage for import identity (`backend.core.x` is not duplicated as `core.x`).

## Acceptance criteria
- No `sys.path.insert()` / `sys.path.append()` in application/runtime Python code.
- No `core.*` application imports remain where `backend.core.*` is the canonical package.
- `python -m compileall` passes.
- Full pytest passes on Python 3.11/3.12.
- `python -m backend.api.main` import path remains valid.
- Uvicorn entrypoint remains valid.
- No duplicate module identity caused by loading the same source as both `core.*` and `backend.core.*`.
- No unrelated production behavior changes.

## Out of scope
- Parser/Semantic Diff redesign
- TypeMapper changes
- API behavior redesign
- Performance work

Follows PR #72 and the Phase 4 import-architecture item in the project development plan.