### PR TITLE
P1: redesign Parser/Semantic Diff around semantic categories

### DIFF
--- a/backend/core/semantic_diff.py
+++ b/backend/core/semantic_diff.py
@@ -148,6 +148,8 @@ def diff_sql_ast(
             differences.append(
                 f"AST node count changed: {node_name} {source_count} -> {target_count}"
             )
+            if not categories:
+                categories = ["structure"]
 
     context_sensitive = sorted(
         set(_context_sensitive_functions(source_tree))
@@ -160,12 +162,12 @@ def diff_sql_ast(
         )
         categories = sorted(set(categories) | {"context_sensitive"})
 
-    if source_normalized == target_normalized and not changed_nodes:
-        status = "unknown" if context_sensitive else "equivalent"
-    elif source_normalized == target_normalized and not context_sensitive:
-        status = "equivalent"
+    if context_sensitive:
+        status = "unknown"
+    elif differences:
+        status = "different"
     else:
-        status = "unknown" if context_sensitive else "different"
+        status = "equivalent"
 
     return SemanticDiff(
         equivalent=status == "equivalent",

--- a/backend/core/semantic_diff.py
+++ b/backend/core/semantic_diff.py
@@ -1,8 +1,8 @@
 """AST-based SQL semantic diff helpers.
 
-The differ deliberately compares SQLGlot's dialect-independent generated SQL and
-its AST node shape. It is a structural regression detector, not a proof of
-runtime equivalence across database engines.
+The differ compares SQLGlot AST structure and canonical SQL. It distinguishes
+syntax failures, structural/semantic differences, and cases where SQL semantics
+cannot be proven from the AST alone.
 """
 from collections import Counter
 from dataclasses import dataclass, field
@@ -13,15 +13,44 @@ import sqlglot
 from sqlglot import exp
 
 
+_CONTEXT_SENSITIVE_FUNCTIONS = {
+    "CURRENT_DATE",
+    "CURRENT_TIME",
+    "CURRENT_TIMESTAMP",
+    "LOCALTIME",
+    "LOCALTIMESTAMP",
+    "NOW",
+    "RAND",
+    "RANDOM",
+    "UUID",
+}
+
+_CATEGORY_NODE_NAMES = {
+    "predicate": {
+        "And", "Between", "Eq", "Exists", "Greater", "GreaterThan", "GT",
+        "GTE", "In", "Is", "Like", "Not", "Or", "RegExp", "Where",
+    },
+    "projection": {"Alias", "Column", "Select", "Star"},
+    "grouping": {"Group", "Having"},
+    "ordering": {"Order", "Ordered"},
+    "row_limit": {"Fetch", "Limit", "Offset"},
+    "join": {"Join"},
+    "aggregate": {"AggFunc", "Count", "Sum", "Avg", "Min", "Max"},
+    "literal_or_type": {"Boolean", "DataType", "Date", "Interval", "Literal", "Null"},
+}
+
+
 @dataclass
 class SemanticDiff:
-    """Structural comparison of two SQL statements."""
+    """Comparison result with an explicit semantic confidence status."""
 
     equivalent: bool
     source_normalized: Optional[str]
     target_normalized: Optional[str]
     differences: List[str] = field(default_factory=list)
     parse_error: Optional[str] = None
+    status: str = "different"
+    difference_categories: List[str] = field(default_factory=list)
 
 
 def _parse_and_normalize(sql: str, dialect: str) -> exp.Expression:
@@ -38,17 +67,44 @@ def _node_counts(tree: exp.Expression) -> Counter[str]:
     return Counter(type(node).__name__ for node in tree.walk())
 
 
+def _context_sensitive_functions(tree: exp.Expression) -> List[str]:
+    names = set()
+    for node in tree.walk():
+        sql_name = getattr(node, "sql_name", None)
+        if not callable(sql_name):
+            continue
+        try:
+            name = str(sql_name()).upper()
+        except Exception:
+            continue
+        if name in _CONTEXT_SENSITIVE_FUNCTIONS:
+            names.add(name)
+    return sorted(names)
+
+
+def _difference_categories(source_tree: exp.Expression, target_tree: exp.Expression) -> List[str]:
+    categories = set()
+    node_names = {type(node).__name__ for node in source_tree.walk()} | {
+        type(node).__name__ for node in target_tree.walk()
+    }
+    for category, candidates in _CATEGORY_NODE_NAMES.items():
+        if node_names & candidates:
+            categories.add(category)
+    return sorted(categories) or ["structure"]
+
+
 def diff_sql_ast(
     source_sql: str,
     target_sql: str,
     source_dialect: str = "",
     target_dialect: str = "",
 ) -> SemanticDiff:
-    """Compare two SQL ASTs after parsing them in their native dialects.
+    """Compare two SQL ASTs and report semantic confidence explicitly.
 
-    Equality means SQLGlot produced the same dialect-independent canonical SQL
-    and the same AST node-type shape. A difference means the conversion should
-    be reviewed; it does not by itself prove the target query is wrong.
+    ``equivalent`` remains backward-compatible: it is true only when the ASTs
+    match and no known context-sensitive construct prevents a safe conclusion.
+    ``status`` is one of ``equivalent``, ``different``, ``unknown``, or
+    ``parse_error``.
     """
     try:
         source_tree = _parse_and_normalize(source_sql, source_dialect)
@@ -60,6 +116,7 @@ def diff_sql_ast(
             target_normalized=None,
             differences=["Unable to parse one or both SQL statements"],
             parse_error=str(exc),
+            status="parse_error",
         )
 
     source_normalized = _canonical_sql(source_tree)
@@ -68,6 +125,7 @@ def diff_sql_ast(
     target_counts = _node_counts(target_tree)
 
     differences: List[str] = []
+    categories: List[str] = []
     if source_normalized != target_normalized:
         diff_lines = list(
             unified_diff(
@@ -80,6 +138,7 @@ def diff_sql_ast(
         )
         differences.append("Canonical AST SQL differs")
         differences.extend(diff_lines[:20])
+        categories = _difference_categories(source_tree, target_tree)
 
     changed_nodes = sorted(set(source_counts) | set(target_counts))
     for node_name in changed_nodes:
@@ -90,11 +149,31 @@ def diff_sql_ast(
                 f"AST node count changed: {node_name} {source_count} -> {target_count}"
             )
 
+    context_sensitive = sorted(
+        set(_context_sensitive_functions(source_tree))
+        | set(_context_sensitive_functions(target_tree))
+    )
+    if context_sensitive:
+        differences.append(
+            "Semantic equivalence is unknown for context-sensitive functions: "
+            + ", ".join(context_sensitive)
+        )
+        categories = sorted(set(categories) | {"context_sensitive"})
+
+    if source_normalized == target_normalized and not changed_nodes:
+        status = "unknown" if context_sensitive else "equivalent"
+    elif source_normalized == target_normalized and not context_sensitive:
+        status = "equivalent"
+    else:
+        status = "unknown" if context_sensitive else "different"
+
     return SemanticDiff(
-        equivalent=not differences,
+        equivalent=status == "equivalent",
         source_normalized=source_normalized,
         target_normalized=target_normalized,
         differences=differences,
+        status=status,
+        difference_categories=categories,
     )
 
 

--- a/backend/core/semantic_diff.py
+++ b/backend/core/semantic_diff.py
@@ -75,8 +75,8 @@ def _context_sensitive_functions(tree: exp.Expression) -> List[str]:
             continue
         try:
             name = str(sql_name()).upper()
-        except Exception:
-            continue
+        except (AttributeError, TypeError, ValueError):
+            name = ""
         if name in _CONTEXT_SENSITIVE_FUNCTIONS:
             names.add(name)
     return sorted(names)

--- a/backend/tests/test_semantic_diff.py
+++ b/backend/tests/test_semantic_diff.py
@@ -10,6 +10,7 @@ def test_semantic_diff_accepts_equivalent_cross_dialect_sql():
     )
 
     assert result.equivalent is True
+    assert result.status == "equivalent"
     assert result.differences == []
 
 
@@ -22,6 +23,8 @@ def test_semantic_diff_detects_predicate_change():
     )
 
     assert result.equivalent is False
+    assert result.status == "different"
+    assert "predicate" in result.difference_categories
     assert any("Canonical AST SQL differs" in item for item in result.differences)
 
 
@@ -34,5 +37,20 @@ def test_semantic_diff_reports_parse_failure():
     )
 
     assert result.equivalent is False
+    assert result.status == "parse_error"
     assert result.parse_error
     assert result.differences == ["Unable to parse one or both SQL statements"]
+
+
+def test_semantic_diff_marks_context_sensitive_functions_unknown():
+    result = diff_sql_ast(
+        "SELECT CURRENT_TIMESTAMP FROM users",
+        "SELECT CURRENT_TIMESTAMP FROM users",
+        source_dialect="postgres",
+        target_dialect="duckdb",
+    )
+
+    assert result.equivalent is False
+    assert result.status == "unknown"
+    assert "context_sensitive" in result.difference_categories
+    assert any("context-sensitive" in item.lower() for item in result.differences)


### PR DESCRIPTION
## Goal
Make Parser/Semantic Diff distinguish syntax validity, structural equivalence, semantic equivalence, and unknown/unsupported semantics without silently treating canonical SQL text equality as proof of meaning.

## Scope
- Preserve existing public `SQLSemanticDiffer.compare()` / `diff_sql_ast()` APIs unless a compatible extension is required.
- Introduce explicit semantic categories/status rather than a single boolean `equivalent` for all comparisons.
- Compare semantic constructs represented in the AST: predicate logic/boolean precedence, NULL-sensitive predicates, projection/group/order/limit shape, joins, aggregates, and literals/types where safely representable.
- Treat unsupported or ambiguous semantic cases as `unknown`/warning, not equivalent.
- Keep parser failures distinct from semantic differences.
- Add focused regression tests before implementation.

## Acceptance criteria
- Existing tests remain green.
- Regression coverage proves at least one false-positive case that current canonical-SQL/node-count comparison misclassifies or cannot classify safely.
- AST comparison does not rely on global SQL string replacement.
- Result exposes actionable differences with stable categories.
- Syntax-invalid input remains a parse failure.
- Unsupported/ambiguous constructs do not silently report semantic equivalence.
- Full CI, semantic-runtime, Quality, CodeQL, compileall, API gate, and wheel smoke remain green.

## Out of scope
- TypeMapper redesign
- API behavior redesign
- Performance work
- Dialect transpiler rewrites

Follows merged PR #73 (Python import architecture).