### PR TITLE
feat: unify middleware-level API 4xx error contract

### DIFF
--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -164,8 +164,16 @@ class StructuredLoggingMiddleware(BaseHTTPMiddleware):
 
     @staticmethod
     async def _normalize_error_response(response: Response, request_id: str) -> Response:
-        """Normalize generic 4xx JSON responses, including streamed responses."""
-        if response.status_code not in {400, 404, 422}:
+        """Normalize standard HTTP 4xx JSON responses while preserving domain-specific codes."""
+        code_by_status = {
+            400: ErrorCode.BAD_REQUEST.value,
+            404: ErrorCode.NOT_FOUND.value,
+            405: ErrorCode.METHOD_NOT_ALLOWED.value,
+            413: ErrorCode.PAYLOAD_TOO_LARGE.value,
+            422: ErrorCode.VALIDATION_FAILED.value,
+            429: ErrorCode.RATE_LIMITED.value,
+        }
+        if response.status_code not in code_by_status:
             return response
 
         try:
@@ -181,46 +189,55 @@ class StructuredLoggingMiddleware(BaseHTTPMiddleware):
             return response
 
         error = payload.get("error") if isinstance(payload, dict) else None
+        expected_code = code_by_status[response.status_code]
         if not isinstance(error, dict):
             detail = payload.get("detail") if isinstance(payload, dict) else None
             if response.status_code == 422:
                 error = {
-                    "code": ErrorCode.VALIDATION_FAILED.value,
+                    "code": expected_code,
                     "message": "Request validation failed",
                     "details": detail if isinstance(detail, list) else ([detail] if detail else []),
                 }
-            elif response.status_code == 404:
+            elif response.status_code == 413:
                 error = {
-                    "code": ErrorCode.NOT_FOUND.value,
-                    "message": str(detail or "Resource not found"),
+                    "code": expected_code,
+                    "message": str(detail or "Request body exceeds the maximum allowed size"),
+                    "details": {},
+                }
+            elif response.status_code == 429:
+                error = {
+                    "code": expected_code,
+                    "message": str(detail or "Rate limit exceeded"),
+                    "details": {},
+                }
+            elif response.status_code == 405:
+                error = {
+                    "code": expected_code,
+                    "message": str(detail or "Method not allowed"),
                     "details": {},
                 }
             else:
                 error = {
-                    "code": ErrorCode.BAD_REQUEST.value,
-                    "message": str(detail or "Bad request"),
+                    "code": expected_code,
+                    "message": str(detail or ("Resource not found" if response.status_code == 404 else "Bad request")),
                     "details": {},
                 }
         else:
             code = error.get("code")
-            if response.status_code == 404 and not isinstance(code, str):
-                error["code"] = ErrorCode.NOT_FOUND.value
-            elif response.status_code == 400 and not isinstance(code, str):
-                error["code"] = ErrorCode.BAD_REQUEST.value
-            elif response.status_code == 422 and not isinstance(code, str):
-                error["code"] = ErrorCode.VALIDATION_FAILED.value
+            if not isinstance(code, str):
+                error["code"] = expected_code
             error.setdefault("details", {})
 
-        payload = {
+        normalized = {
             "success": False,
             "error": error,
-            "timestamp": payload.get("timestamp", datetime.now().isoformat()),
+            "timestamp": payload.get("timestamp", datetime.now().isoformat()) if isinstance(payload, dict) else datetime.now().isoformat(),
             "request_id": request_id,
         }
         headers = dict(response.headers)
         headers.pop("content-length", None)
         headers.pop("content-type", None)
-        return JSONResponse(status_code=response.status_code, content=payload, headers=headers)
+        return JSONResponse(status_code=response.status_code, content=normalized, headers=headers)
 
     async def dispatch(self, request: Request, call_next) -> Response:
         start_time = time.time()

--- a/backend/core/exceptions.py
+++ b/backend/core/exceptions.py
@@ -80,3 +80,45 @@ class ParseError(SDMException):
     def __init__(self, message: str, sql: str = None, dialect: str = None):
         details = {"sql": sql[:200] if sql else None, "dialect": dialect}
         super().__init__(message, details)
+
+
+class SecurityViolationError(SDMException):
+    """Raised when SQL contains potentially dangerous patterns."""
+
+    error_code = ErrorCode.SECURITY_VIOLATION
+
+    def __init__(self, message: str, pattern: str = None):
+        details = {"pattern": pattern}
+        super().__init__(message, details)
+
+
+class ValidationError(SDMException):
+    """Raised when input validation fails."""
+
+    error_code = ErrorCode.VALIDATION_FAILED
+
+    def __init__(self, message: str, field: str = None, value: str = None):
+        details = {"field": field, "value": value}
+        super().__init__(message, details)
+
+
+class CacheError(SDMException):
+    """Raised when cache operations fail."""
+
+    error_code = ErrorCode.CACHE_FAILED
+
+
+class ConfigurationError(SDMException):
+    """Raised when configuration is invalid."""
+
+    error_code = ErrorCode.CONFIGURATION_INVALID
+
+
+class RuleConflictError(SDMException):
+    """Raised when transformation rules conflict."""
+
+    error_code = ErrorCode.RULE_CONFLICT
+
+    def __init__(self, message: str, rule1: str = None, rule2: str = None):
+        details = {"rule1": rule1, "rule2": rule2}
+        super().__init__(message, details)

--- a/backend/core/exceptions.py
+++ b/backend/core/exceptions.py
@@ -14,6 +14,9 @@ class ErrorCode(str, Enum):
     VALIDATION_FAILED = "VALIDATION_FAILED"
     BAD_REQUEST = "BAD_REQUEST"
     NOT_FOUND = "NOT_FOUND"
+    METHOD_NOT_ALLOWED = "METHOD_NOT_ALLOWED"
+    PAYLOAD_TOO_LARGE = "PAYLOAD_TOO_LARGE"
+    RATE_LIMITED = "RATE_LIMITED"
     CACHE_FAILED = "CACHE_FAILED"
     CONFIGURATION_INVALID = "CONFIGURATION_INVALID"
     RULE_CONFLICT = "RULE_CONFLICT"
@@ -76,46 +79,4 @@ class ParseError(SDMException):
 
     def __init__(self, message: str, sql: str = None, dialect: str = None):
         details = {"sql": sql[:200] if sql else None, "dialect": dialect}
-        super().__init__(message, details)
-
-
-class SecurityViolationError(SDMException):
-    """Raised when SQL contains potentially dangerous patterns."""
-
-    error_code = ErrorCode.SECURITY_VIOLATION
-
-    def __init__(self, message: str, pattern: str = None):
-        details = {"pattern": pattern}
-        super().__init__(message, details)
-
-
-class ValidationError(SDMException):
-    """Raised when input validation fails."""
-
-    error_code = ErrorCode.VALIDATION_FAILED
-
-    def __init__(self, message: str, field: str = None, value: str = None):
-        details = {"field": field, "value": value}
-        super().__init__(message, details)
-
-
-class CacheError(SDMException):
-    """Raised when cache operations fail."""
-
-    error_code = ErrorCode.CACHE_FAILED
-
-
-class ConfigurationError(SDMException):
-    """Raised when configuration is invalid."""
-
-    error_code = ErrorCode.CONFIGURATION_INVALID
-
-
-class RuleConflictError(SDMException):
-    """Raised when transformation rules conflict."""
-
-    error_code = ErrorCode.RULE_CONFLICT
-
-    def __init__(self, message: str, rule1: str = None, rule2: str = None):
-        details = {"rule1": rule1, "rule2": rule2}
         super().__init__(message, details)

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -4,11 +4,14 @@ from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
 from backend.api.middleware import (
+    DEFAULT_MAX_REQUEST_BODY_BYTES,
     RateLimitMiddleware,
     RateLimiter,
     SecurityHeadersMiddleware,
-    DEFAULT_MAX_REQUEST_BODY_BYTES,
+    StructuredLoggingMiddleware,
 )
+
+REQUEST_ID = "12345678-1234-4123-8123-123456789abc"
 
 
 def make_app(rate_limit: int = 2) -> FastAPI:
@@ -17,6 +20,7 @@ def make_app(rate_limit: int = 2) -> FastAPI:
 
     app.add_middleware(SecurityHeadersMiddleware)
     app.add_middleware(RateLimitMiddleware, limiter=limiter, enabled=True)
+    app.add_middleware(StructuredLoggingMiddleware)
 
     @app.get("/api/test")
     async def test_endpoint():
@@ -33,6 +37,16 @@ def make_app(rate_limit: int = 2) -> FastAPI:
     return app
 
 
+def assert_standard_error(response, status_code: int, error_code: str, request_id: str = REQUEST_ID):
+    assert response.status_code == status_code
+    data = response.json()
+    assert data["success"] is False
+    assert data["error"]["code"] == error_code
+    assert "timestamp" in data
+    assert data["request_id"] == request_id
+    assert response.headers["X-Request-ID"] == request_id
+
+
 def test_rate_limit_headers_are_added():
     client = TestClient(make_app(rate_limit=2))
     response = client.get("/api/test")
@@ -42,15 +56,15 @@ def test_rate_limit_headers_are_added():
     assert "X-RateLimit-Reset" in response.headers
 
 
-def test_rate_limit_returns_429_after_limit():
+def test_rate_limit_returns_429_with_standard_contract():
     client = TestClient(make_app(rate_limit=1))
-    first = client.get("/api/test")
-    second = client.get("/api/test")
+    first = client.get("/api/test", headers={"X-Request-ID": REQUEST_ID})
+    second = client.get("/api/test", headers={"X-Request-ID": REQUEST_ID})
     assert first.status_code == 200
-    assert second.status_code == 429
+    assert_standard_error(second, 429, "RATE_LIMITED")
     assert second.headers["Retry-After"].isdigit()
     assert second.headers["X-RateLimit-Remaining"] == "0"
-    assert second.json()["error"]["code"] == 429
+    assert "retry_after" in second.json()["error"]
 
 
 def test_forwarded_for_cannot_change_client_identity():
@@ -68,16 +82,32 @@ def test_health_check_bypasses_rate_limit():
     assert client.get("/health").status_code == 200
 
 
-def test_oversized_content_length_is_rejected_before_body_processing():
+def test_oversized_content_length_uses_payload_too_large_contract():
     client = TestClient(make_app(rate_limit=100))
     response = client.post(
         "/api/echo",
         content=b"x",
-        headers={"Content-Length": str(DEFAULT_MAX_REQUEST_BODY_BYTES + 1)},
+        headers={"Content-Length": str(DEFAULT_MAX_REQUEST_BODY_BYTES + 1), "X-Request-ID": REQUEST_ID},
     )
-    assert response.status_code == 413
-    assert response.json()["error"]["code"] == 413
+    assert_standard_error(response, 413, "PAYLOAD_TOO_LARGE")
     assert response.json()["error"]["max_bytes"] == DEFAULT_MAX_REQUEST_BODY_BYTES
+
+
+def test_invalid_content_length_uses_bad_request_contract():
+    client = TestClient(make_app(rate_limit=100))
+    response = client.post(
+        "/api/echo",
+        content=b"x",
+        headers={"Content-Length": "invalid", "X-Request-ID": REQUEST_ID},
+    )
+    assert_standard_error(response, 400, "BAD_REQUEST")
+    assert response.json()["error"]["message"] == "Invalid Content-Length"
+
+
+def test_method_not_allowed_uses_standard_contract():
+    client = TestClient(make_app(rate_limit=100))
+    response = client.post("/api/test", headers={"X-Request-ID": REQUEST_ID})
+    assert_standard_error(response, 405, "METHOD_NOT_ALLOWED")
 
 
 def test_security_headers_are_present():


### PR DESCRIPTION
## Summary
- extend the stable API error taxonomy to middleware-generated `405`, `413`, and `429` responses
- normalize request-size and rate-limit responses into the same `{success,error,timestamp,request_id}` envelope
- preserve rate-limit headers and domain-specific string error codes
- add regression coverage for 400/405/413/429 middleware paths

## Error codes
- `400` -> `BAD_REQUEST`
- `404` -> `NOT_FOUND`
- `405` -> `METHOD_NOT_ALLOWED`
- `413` -> `PAYLOAD_TOO_LARGE`
- `422` -> `VALIDATION_FAILED`
- `429` -> `RATE_LIMITED`
- existing string/domain error codes remain unchanged

## Validation
- updated middleware regression tests
- full repository CI required before merge