### PR TITLE
test: tighten Semantic Diff category precision

### DIFF
--- a/backend/core/semantic_diff.py
+++ b/backend/core/semantic_diff.py
@@ -97,20 +97,61 @@ def _context_sensitive_functions(tree: exp.Expression) -> List[str]:
     return sorted(names)
 
 
+def _fragment_sql(node: Optional[exp.Expression]) -> str:
+    if node is None:
+        return ""
+    return node.sql(dialect="", pretty=False).strip()
+
+
+def _list_fragment_sql(nodes) -> str:
+    return "\n".join(_fragment_sql(node) for node in nodes)
+
+
 def _difference_categories(
     source_tree: exp.Expression,
     target_tree: exp.Expression,
     functions_differ: bool = False,
 ) -> List[str]:
+    """Return categories whose semantic regions actually changed."""
     categories = set()
-    node_names = {type(node).__name__ for node in source_tree.walk()} | {
-        type(node).__name__ for node in target_tree.walk()
-    }
-    for category, candidates in _CATEGORY_NODE_NAMES.items():
-        if node_names & candidates:
-            categories.add(category)
+    source_select = source_tree if isinstance(source_tree, exp.Select) else source_tree.find(exp.Select)
+    target_select = target_tree if isinstance(target_tree, exp.Select) else target_tree.find(exp.Select)
+
+    if source_select is not None and target_select is not None:
+        if _list_fragment_sql(source_select.expressions) != _list_fragment_sql(target_select.expressions):
+            categories.add("projection")
+        if _fragment_sql(source_select.args.get("where")) != _fragment_sql(target_select.args.get("where")):
+            categories.add("predicate")
+        if _fragment_sql(source_select.args.get("having")) != _fragment_sql(target_select.args.get("having")):
+            categories.add("predicate")
+            categories.add("grouping")
+        if _fragment_sql(source_select.args.get("group")) != _fragment_sql(target_select.args.get("group")):
+            categories.add("grouping")
+        if _fragment_sql(source_select.args.get("order")) != _fragment_sql(target_select.args.get("order")):
+            categories.add("ordering")
+        if _fragment_sql(source_select.args.get("limit")) != _fragment_sql(target_select.args.get("limit")):
+            categories.add("row_limit")
+        if _fragment_sql(source_select.args.get("offset")) != _fragment_sql(target_select.args.get("offset")):
+            categories.add("row_limit")
+
+    source_joins = list(source_tree.find_all(exp.Join))
+    target_joins = list(target_tree.find_all(exp.Join))
+    if _list_fragment_sql(source_joins) != _list_fragment_sql(target_joins):
+        categories.add("join")
+
+    source_aggregates = list(source_tree.find_all(exp.AggFunc))
+    target_aggregates = list(target_tree.find_all(exp.AggFunc))
+    if _list_fragment_sql(source_aggregates) != _list_fragment_sql(target_aggregates):
+        categories.add("aggregate")
+
+    source_literals = [node for node in source_tree.walk() if type(node).__name__ in _CATEGORY_NODE_NAMES["literal_or_type"]]
+    target_literals = [node for node in target_tree.walk() if type(node).__name__ in _CATEGORY_NODE_NAMES["literal_or_type"]]
+    if _list_fragment_sql(source_literals) != _list_fragment_sql(target_literals):
+        categories.add("literal_or_type")
+
     if functions_differ:
         categories.add("function")
+
     return sorted(categories) or ["structure"]
 
 

--- a/backend/tests/test_semantic_diff_categories_p1.py
+++ b/backend/tests/test_semantic_diff_categories_p1.py
@@ -59,7 +59,7 @@ def test_join_only_change_reports_join_without_projection():
         target_dialect="postgres",
     )
 
-    assert result.difference_categories == ["join", "predicate"]
+    assert result.difference_categories == ["join"]
 
 
 def test_limit_only_change_reports_row_limit():

--- a/backend/tests/test_semantic_diff_categories_p1.py
+++ b/backend/tests/test_semantic_diff_categories_p1.py
@@ -27,3 +27,47 @@ def test_semantic_diff_reports_multiple_relevant_categories():
     assert {"predicate", "aggregate", "ordering", "row_limit", "grouping"}.issubset(
         set(result.difference_categories)
     )
+
+
+def test_predicate_only_change_does_not_report_projection_or_join():
+    result = diff_sql_ast(
+        "SELECT id FROM users WHERE active = 1",
+        "SELECT id FROM users WHERE active = 0",
+        source_dialect="postgres",
+        target_dialect="postgres",
+    )
+
+    assert result.difference_categories == ["literal_or_type", "predicate"]
+
+
+def test_projection_only_change_reports_projection():
+    result = diff_sql_ast(
+        "SELECT id FROM users",
+        "SELECT name FROM users",
+        source_dialect="postgres",
+        target_dialect="postgres",
+    )
+
+    assert result.difference_categories == ["projection"]
+
+
+def test_join_only_change_reports_join_without_projection():
+    result = diff_sql_ast(
+        "SELECT users.id FROM users",
+        "SELECT users.id FROM users JOIN departments ON users.department_id = departments.id",
+        source_dialect="postgres",
+        target_dialect="postgres",
+    )
+
+    assert result.difference_categories == ["join", "predicate"]
+
+
+def test_limit_only_change_reports_row_limit():
+    result = diff_sql_ast(
+        "SELECT id FROM users LIMIT 10",
+        "SELECT id FROM users LIMIT 20",
+        source_dialect="postgres",
+        target_dialect="postgres",
+    )
+
+    assert result.difference_categories == ["literal_or_type", "row_limit"]

--- a/backend/tests/test_semantic_diff_categories_p1.py
+++ b/backend/tests/test_semantic_diff_categories_p1.py
@@ -14,7 +14,7 @@ def test_function_changes_are_reported_as_function_category():
     assert "function" in result.difference_categories
 
 
-def test_semantic_diff_reports_multiple_relevant_categories():
+def test_semantic_diff_reports_only_changed_relevant_categories():
     result = diff_sql_ast(
         "SELECT department, COUNT(*) FROM users WHERE active = 1 GROUP BY department ORDER BY COUNT(*) DESC LIMIT 10",
         "SELECT department, COUNT(*) FROM users WHERE active = 0 GROUP BY department ORDER BY COUNT(*) ASC LIMIT 20",
@@ -24,9 +24,12 @@ def test_semantic_diff_reports_multiple_relevant_categories():
 
     assert result.equivalent is False
     assert result.status == "different"
-    assert {"predicate", "aggregate", "ordering", "row_limit", "grouping"}.issubset(
-        set(result.difference_categories)
-    )
+    assert result.difference_categories == [
+        "literal_or_type",
+        "ordering",
+        "predicate",
+        "row_limit",
+    ]
 
 
 def test_predicate_only_change_does_not_report_projection_or_join():


### PR DESCRIPTION
## Summary
- classify Semantic Diff categories from changed semantic regions rather than node presence alone
- prevent unrelated projection/join categories from appearing on predicate-only changes
- preserve multi-category detection for query changes spanning predicate, grouping, ordering, aggregate, and row-limit regions

## Scope
Small production change plus focused regression tests. No API surface change.

## Validation
- full repository CI required before merge