### PR TITLE
test: cover readiness cache TTL expiry

### DIFF
--- a/backend/tests/test_readiness_cache_ttl.py
+++ b/backend/tests/test_readiness_cache_ttl.py
@@ -1,0 +1,34 @@
+import asyncio
+import time
+
+from backend.api import readiness
+
+
+def test_readiness_cache_refreshes_after_ttl(monkeypatch):
+    async def exercise():
+        calls = 0
+
+        def fake_probe():
+            nonlocal calls
+            calls += 1
+            return {"transpiler": {"status": "ok"}}
+
+        monkeypatch.setattr(readiness, "_run_checks", fake_probe)
+        original_ttl = readiness._READINESS_CACHE_TTL_SECONDS
+        readiness._READINESS_CACHE_TTL_SECONDS = 30.0
+        readiness._cached_checks = {"transpiler": {"status": "stale"}}
+        readiness._cached_at = time.monotonic() - 31.0
+        try:
+            first = await readiness._get_checks()
+            second = await readiness._get_checks()
+            assert first == {"transpiler": {"status": "ok"}}
+            assert second == first
+            assert calls == 1
+        finally:
+            readiness._READINESS_CACHE_TTL_SECONDS = original_ttl
+            readiness._cached_checks = None
+            readiness._cached_at = 0.0
+            readiness._READINESS_CACHE["checks"] = None
+            readiness._READINESS_CACHE["cached_at"] = 0.0
+
+    asyncio.run(exercise())


### PR DESCRIPTION
## Summary
- cover the readiness cache expiration boundary after the configured TTL
- verify an expired cache triggers exactly one fresh probe and subsequent calls reuse the refreshed result

## Scope
Tests only. No production behavior change.

## Validation
Full repository CI required before merge.