### PR TITLE
test: lock down transpiler cache key identity

### DIFF
--- a/backend/tests/test_transpiler_cache_key_contract.py
+++ b/backend/tests/test_transpiler_cache_key_contract.py
@@ -1,0 +1,49 @@
+from backend.core.transpiler import SQLTranspiler
+
+
+def test_cache_key_separates_validation_mode() -> None:
+    transpiler = SQLTranspiler()
+
+    validated = transpiler._cache_key(
+        "SELECT 1", "postgres", "mysql", pretty=True, validate=True
+    )
+    unvalidated = transpiler._cache_key(
+        "SELECT 1", "postgres", "mysql", pretty=True, validate=False
+    )
+
+    assert validated != unvalidated
+
+
+def test_cache_key_changes_when_rule_contract_changes() -> None:
+    transpiler = SQLTranspiler()
+    baseline = transpiler._cache_key("SELECT 1", "postgres", "mysql")
+
+    rule = transpiler.post_processor.engine.rules[0]
+    original_pattern = rule.pattern
+    try:
+        rule.pattern = original_pattern + "_cache_contract"
+        changed = transpiler._cache_key("SELECT 1", "postgres", "mysql")
+    finally:
+        rule.pattern = original_pattern
+
+    assert changed != baseline
+
+
+def test_transpile_does_not_reuse_validated_cache_for_unvalidated_mode() -> None:
+    transpiler = SQLTranspiler()
+    sql = "SELECT 1"
+
+    validated = transpiler.transpile(
+        sql, "postgres", "mysql", pretty=True, validate=True
+    )
+    unvalidated = transpiler.transpile(
+        sql, "postgres", "mysql", pretty=True, validate=False
+    )
+
+    assert validated.success is True
+    assert unvalidated.success is True
+    assert transpiler._cache_key(
+        sql, "postgres", "mysql", pretty=True, validate=True
+    ) != transpiler._cache_key(
+        sql, "postgres", "mysql", pretty=True, validate=False
+    )

--- a/backend/tests/test_transpiler_cache_key_contract.py
+++ b/backend/tests/test_transpiler_cache_key_contract.py
@@ -16,13 +16,17 @@ def test_cache_key_separates_validation_mode() -> None:
 
 def test_cache_key_changes_when_rule_contract_changes() -> None:
     transpiler = SQLTranspiler()
-    baseline = transpiler._cache_key("SELECT 1", "postgres", "mysql")
+    baseline = transpiler._cache_key(
+        "SELECT 1", "postgres", "mysql", pretty=True, validate=True
+    )
 
     rule = transpiler.post_processor.engine.rules[0]
     original_pattern = rule.pattern
     try:
         rule.pattern = original_pattern + "_cache_contract"
-        changed = transpiler._cache_key("SELECT 1", "postgres", "mysql")
+        changed = transpiler._cache_key(
+            "SELECT 1", "postgres", "mysql", pretty=True, validate=True
+        )
     finally:
         rule.pattern = original_pattern
 


### PR DESCRIPTION
## Summary
- separate validated and unvalidated transpilation cache entries
- verify rule-definition changes invalidate the transpiler cache identity
- cover cache-key identity as a regression contract

## Scope
Tests only. No production behavior changes.