### PR TITLE
ci: retain benchmark JSON artifacts

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -61,3 +61,11 @@ jobs:
           print()
           print("Benchmark is informational in CI; it does not enforce a fixed latency threshold.")
           PY
+
+      - name: Upload benchmark JSON
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: transpiler-benchmark-${{ github.sha }}
+          path: benchmark.json
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
Closes #115

## Scope
- retain the existing reproducible `benchmark.json` output as a GitHub Actions artifact
- keep the existing informational Job Summary and no fixed latency threshold
- pin `actions/upload-artifact` to an immutable commit

No production runtime behavior changes.