### PR TITLE
perf: reuse parsed statement result in security validation

### DIFF
--- a/backend/core/transpiler.py
+++ b/backend/core/transpiler.py
@@ -123,11 +123,13 @@ class SQLTranspiler:
         logger.debug(f"Input SQL: {sql[:200]}{'...' if len(sql) > 200 else ''}")
 
         security_warnings: List[str] = []
+        multiple_statements: Optional[bool] = None
         security_enabled = settings.security_check_enabled
         self._security_enabled = security_enabled
         if security_enabled:
             security_result = self._validate_security(sql)
             security_warnings = list(security_result["warnings"])
+            multiple_statements = security_result.get("multiple_statements")
             if security_result["blocked"]:
                 logger.warning(f"SQL blocked by security check: {security_result['reason']}")
                 return TranspileResult(
@@ -140,7 +142,9 @@ class SQLTranspiler:
                     warnings=security_warnings
                 )
 
-        if self._has_multiple_statements(sql):
+        if multiple_statements is None:
+            multiple_statements = self._has_multiple_statements(sql)
+        if multiple_statements:
             return TranspileResult(
                 success=False,
                 source_sql=sql,
@@ -321,7 +325,8 @@ class SQLTranspiler:
             result["warnings"].append(f"🔒 Security: {message}")
         try:
             parsed_statements = sqlglot.parse(sql)
-            if len(parsed_statements) > 1:
+            result["multiple_statements"] = len(parsed_statements) > 1
+            if result["multiple_statements"]:
                 message = "Multiple SQL statements detected"
                 if settings.security_block_dangerous:
                     result["blocked"] = True

--- a/backend/tests/test_transpiler_security_parse_reuse.py
+++ b/backend/tests/test_transpiler_security_parse_reuse.py
@@ -1,0 +1,46 @@
+from backend.core.config import settings
+from backend.core.transpiler import SQLTranspiler
+
+
+def test_security_enabled_multiple_statements_keep_security_violation(monkeypatch):
+    monkeypatch.setattr(settings, "security_check_enabled", True)
+    monkeypatch.setattr(settings, "security_block_dangerous", True)
+
+    result = SQLTranspiler().transpile(
+        "SELECT 1; SELECT 2",
+        "mysql",
+        "postgres",
+    )
+
+    assert result.success is False
+    assert result.error_code == "SECURITY_VIOLATION"
+    assert "Multiple SQL statements detected" in result.error
+
+
+def test_security_enabled_allow_mode_keeps_validation_failed_for_multiple_statements(monkeypatch):
+    monkeypatch.setattr(settings, "security_check_enabled", True)
+    monkeypatch.setattr(settings, "security_block_dangerous", False)
+
+    result = SQLTranspiler().transpile(
+        "SELECT 1; SELECT 2",
+        "mysql",
+        "postgres",
+    )
+
+    assert result.success is False
+    assert result.error_code == "VALIDATION_FAILED"
+    assert "Multiple SQL statements are not supported" in result.error
+
+
+def test_security_disabled_keeps_validation_failed_for_multiple_statements(monkeypatch):
+    monkeypatch.setattr(settings, "security_check_enabled", False)
+
+    result = SQLTranspiler().transpile(
+        "SELECT 1; SELECT 2",
+        "mysql",
+        "postgres",
+    )
+
+    assert result.success is False
+    assert result.error_code == "VALIDATION_FAILED"
+    assert "Multiple SQL statements are not supported" in result.error


### PR DESCRIPTION
## Summary
- reuse the security-phase multi-statement parse result in `transpile()`
- keep the existing `SECURITY_VIOLATION` vs `VALIDATION_FAILED` behavior
- add focused regressions for security enabled/blocked, security enabled/allowed, and security disabled modes

## Performance evidence
The current main benchmark is 100 statements × 3 repeats, mysql → postgres, cache disabled: sync `0.2133s`, async `0.2220s`, async speedup `0.961x`. This PR targets redundant parsing only; it does not change the async concurrency model.

After merge, benchmark artifacts will provide the directly comparable post-change measurement.

Closes #117