### PR TITLE
perf: reuse cache key on cache miss

### DIFF
--- a/backend/core/transpiler.py
+++ b/backend/core/transpiler.py
@@ -211,7 +211,6 @@ class SQLTranspiler:
             )
 
             if self._cache_enabled:
-                cache_key = self._cache_key(sql, source, target, pretty, validate)
                 self._cache.set(cache_key, result.to_dict())
             return result
         except Exception as e:

--- a/backend/tests/test_transpiler_cache_key_reuse.py
+++ b/backend/tests/test_transpiler_cache_key_reuse.py
@@ -1,0 +1,50 @@
+from backend.core.config import settings
+from backend.core.transpiler import SQLTranspiler
+
+
+def test_cache_miss_reuses_computed_key_for_cache_set(monkeypatch):
+    monkeypatch.setattr(settings, "security_check_enabled", False)
+
+    transpiler = SQLTranspiler()
+    transpiler._cache_enabled = True
+    transpiler._cache.clear()
+
+    calls = []
+    original_cache_key = transpiler._cache_key
+
+    def spy_cache_key(sql, source, target, pretty, validate):
+        calls.append(1)
+        return original_cache_key(sql, source, target, pretty, validate)
+
+    monkeypatch.setattr(transpiler, "_cache_key", spy_cache_key)
+
+    result = transpiler.transpile("SELECT 1", "mysql", "postgres")
+
+    assert result.success is True
+    assert len(calls) == 1
+
+
+def test_cache_hit_still_computes_key_once(monkeypatch):
+    monkeypatch.setattr(settings, "security_check_enabled", False)
+
+    transpiler = SQLTranspiler()
+    transpiler._cache_enabled = True
+    transpiler._cache.clear()
+
+    first = transpiler.transpile("SELECT 1", "mysql", "postgres")
+    assert first.success is True
+
+    calls = []
+    original_cache_key = transpiler._cache_key
+
+    def spy_cache_key(sql, source, target, pretty, validate):
+        calls.append(1)
+        return original_cache_key(sql, source, target, pretty, validate)
+
+    monkeypatch.setattr(transpiler, "_cache_key", spy_cache_key)
+
+    cached = transpiler.transpile("SELECT 1", "mysql", "postgres")
+
+    assert cached.success is True
+    assert cached.target_sql == first.target_sql
+    assert len(calls) == 1


### PR DESCRIPTION
## Scope
- compute the transpiler cache key once on a cache-enabled request and reuse it for cache insertion
- preserve cache identity and public APIs
- add regression coverage for one key computation on cache miss and cache hit

## Evidence
- production diff: 1 line removed in `backend/core/transpiler.py`
- regression test: 2 focused cases in `backend/tests/test_transpiler_cache_key_reuse.py`
- the standard benchmark intentionally disables cache, so it does not measure this cache-path optimization; correctness is locked down by invocation-count tests instead.