### PR TITLE
perf: profile transpiler hot-path cost breakdown

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,6 +59,19 @@ jobs:
           print(f"- Async mean: `{async_mean:.4f}s`")
           print(f"- Async speedup: `{speedup:.2f}x`")
           print()
+          print("### Profiling hotspots")
+          for config in payload["profiling"]["configurations"]:
+              label = (
+                  f"cache={config['cache_enabled']}, "
+                  f"security={config['security_enabled']}, "
+                  f"validate={config['validate']}"
+              )
+              hotspots = ", ".join(
+                  f"{item['stage']} ({item['percent_of_mean']:.1f}%)"
+                  for item in config["top_hotspots"]
+              )
+              print(f"- `{label}`: {hotspots}")
+          print()
           print("Benchmark is informational in CI; it does not enforce a fixed latency threshold.")
           PY
 

--- a/backend/benchmarks/transpiler_benchmark.py
+++ b/backend/benchmarks/transpiler_benchmark.py
@@ -52,12 +52,6 @@ class StageRecorder:
             self.totals[name] = self.totals.get(name, 0.0) + elapsed
             self.calls[name] = self.calls.get(name, 0) + 1
 
-    def snapshot(self) -> Dict[str, object]:
-        return {
-            "timings_seconds": dict(self.totals),
-            "calls": dict(self.calls),
-        }
-
 
 def build_statements(iterations: int) -> List[str]:
     """Create a stable workload without depending on external data."""
@@ -119,14 +113,13 @@ def _wrap_instance_method(
 
 
 def _instrument_transpiler(transpiler: SQLTranspiler, recorder: StageRecorder) -> None:
-    """Instrument stage boundaries that already exist in the transpiler."""
+    """Instrument existing transpiler stage boundaries from the benchmark process."""
     method_stages = {
         "_validate_security": "security_checks",
         "_has_multiple_statements": "statement_validation",
         "_cache_key": "cache_key",
         "_get_compatibility_notes": "compatibility_notes",
         "_generate_warnings_masked": "warnings",
-        "_generate_warnings": "warnings",
         "_validate_output_detailed": "output_validation",
     }
     for name, stage in method_stages.items():
@@ -156,10 +149,11 @@ def _measure_sqlglot_and_postprocess(
     validate: bool,
     recorder: StageRecorder,
 ) -> float:
-    """Measure the normal synchronous pipeline with SQLGlot/post-process hooks."""
+    """Measure the synchronous pipeline with SQLGlot/post-process hooks."""
     original_transpile = sqlglot.transpile
     original_process = transpiler.post_processor.process
-    original_mask = __import__("backend.core.transpiler", fromlist=["mask_non_executable"]).mask_non_executable
+    transpiler_module = __import__("backend.core.transpiler", fromlist=["mask_non_executable"])
+    original_mask = transpiler_module.mask_non_executable
 
     def timed_transpile(*args, **kwargs):
         with recorder.time_call("sqlglot_transpile"):
@@ -180,7 +174,7 @@ def _measure_sqlglot_and_postprocess(
         return measure_sync(transpiler, statements, source, target, validate=validate)
 
 
-def measure_input_validation(repeats: int) -> Dict[str, float]:
+def measure_input_validation(repeats: int) -> Dict[str, object]:
     """Measure the public type-validation fast path without changing behavior."""
     timings: List[float] = []
     transpiler = SQLTranspiler()
@@ -224,21 +218,18 @@ def profile_configuration(
             timings.append(elapsed)
 
         total_mean = mean(timings)
-        stage_timings = aggregate.totals
         per_statement = {
-            name: value / len(statements) / repeats for name, value in stage_timings.items()
+            name: value / len(statements) / repeats
+            for name, value in aggregate.totals.items()
         }
-        known_stage_total = sum(per_statement.values())
-        residual = max(total_mean / len(statements) - known_stage_total, 0.0)
-        per_statement["orchestration_and_inline_validation"] = residual
-        percentages = {
+        per_statement_percent = {
             name: (value / (total_mean / len(statements)) * 100.0)
             if total_mean
             else 0.0
             for name, value in per_statement.items()
         }
         hotspots = sorted(
-            percentages.items(), key=lambda item: item[1], reverse=True
+            per_statement_percent.items(), key=lambda item: item[1], reverse=True
         )[:2]
 
         return {
@@ -250,7 +241,7 @@ def profile_configuration(
             "mean_seconds": total_mean,
             "median_seconds": median(timings),
             "per_statement_seconds": per_statement,
-            "stage_percent_of_mean": percentages,
+            "stage_percent_of_mean": per_statement_percent,
             "stage_calls": aggregate.calls,
             "top_hotspots": [
                 {"stage": name, "percent_of_mean": percent}
@@ -320,7 +311,7 @@ def main() -> None:
         "environment": {
             "python": platform.python_version(),
             "platform": platform.platform(),
-            "sqlglot": sqlglot.__version__,
+            "sqlglot": getattr(sqlglot, "__version__", "unknown"),
         },
         "workload": {
             "iterations": args.iterations,
@@ -340,13 +331,15 @@ def main() -> None:
         },
         "async_speedup": speedup,
         "profiling": {
+            "stage_timing_model": "inclusive",
             "configurations": configurations,
             "notes": [
                 "Stage timings are benchmark-process instrumentation, not production telemetry.",
-                "orchestration_and_inline_validation is residual wall time after instrumented stage calls.",
+                "Stage percentages are inclusive and can overlap when one measured call invokes another.",
+                "Input validation is measured separately on invalid public inputs because successful-path type checks are inline.",
                 "validate is a function argument rather than an application settings switch.",
                 "Cache-enabled measurements use a new transpiler per repeat, so each run starts cold.",
-                "top_hotspots ranks the two largest measured contributors for each configuration.",
+                "top_hotspots ranks the two largest inclusive contributors for each configuration.",
             ],
         },
     }, ensure_ascii=False, indent=2))

--- a/backend/benchmarks/transpiler_benchmark.py
+++ b/backend/benchmarks/transpiler_benchmark.py
@@ -1,18 +1,27 @@
 #!/usr/bin/env python3
-"""Small reproducible benchmark for synchronous vs asynchronous transpilation.
+"""Reproducible benchmark for transpiler wall time and hot-path stage cost.
 
 The benchmark intentionally avoids a pass/fail performance threshold. Runtime
 performance varies across CI and developer machines; this command is for
 observability and regression investigation rather than correctness gating.
+Instrumentation is applied from this benchmark process only; production code
+is not modified by the profiling harness.
 """
 
 import argparse
 import asyncio
 import json
+import platform
 import time
-from statistics import mean
-from typing import Callable, List
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from statistics import mean, median
+from typing import Callable, Dict, Iterator, List
+from unittest.mock import patch
 
+import sqlglot
+
+from backend.core.config import settings
 from backend.core.transpiler import SQLTranspiler
 
 
@@ -22,6 +31,32 @@ DEFAULT_STATEMENTS = [
     "SELECT o.id, o.total, c.name FROM orders o JOIN customers c ON o.customer_id = c.id",
     "SELECT DATE_FORMAT(created_at, '%Y-%m-%d') AS day, COUNT(*) FROM events GROUP BY day",
 ]
+
+INVALID_INPUTS = [None, 42, True]
+
+
+@dataclass
+class StageRecorder:
+    """Accumulate inclusive wall-clock time for instrumented callables."""
+
+    totals: Dict[str, float] = field(default_factory=dict)
+    calls: Dict[str, int] = field(default_factory=dict)
+
+    @contextmanager
+    def time_call(self, name: str) -> Iterator[None]:
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            elapsed = time.perf_counter() - start
+            self.totals[name] = self.totals.get(name, 0.0) + elapsed
+            self.calls[name] = self.calls.get(name, 0) + 1
+
+    def snapshot(self) -> Dict[str, object]:
+        return {
+            "timings_seconds": dict(self.totals),
+            "calls": dict(self.calls),
+        }
 
 
 def build_statements(iterations: int) -> List[str]:
@@ -66,6 +101,146 @@ def measure_repeated(capture: Callable[[], float], repeats: int) -> List[float]:
     return [capture() for _ in range(repeats)]
 
 
+def _wrap_instance_method(
+    transpiler: SQLTranspiler,
+    name: str,
+    recorder: StageRecorder,
+    stage: str,
+) -> None:
+    """Wrap one bound instance method without changing production code."""
+    original = getattr(transpiler, name)
+
+    def wrapped(*args, **kwargs):
+        with recorder.time_call(stage):
+            return original(*args, **kwargs)
+
+    setattr(transpiler, name, wrapped)
+
+
+def _instrument_transpiler(transpiler: SQLTranspiler, recorder: StageRecorder) -> None:
+    """Instrument stage boundaries that already exist in the transpiler."""
+    method_stages = {
+        "_validate_security": "security_checks",
+        "_has_multiple_statements": "statement_validation",
+        "_cache_key": "cache_key",
+        "_get_compatibility_notes": "compatibility_notes",
+        "_generate_warnings_masked": "warnings",
+        "_generate_warnings": "warnings",
+        "_validate_output_detailed": "output_validation",
+    }
+    for name, stage in method_stages.items():
+        if hasattr(transpiler, name):
+            _wrap_instance_method(transpiler, name, recorder, stage)
+
+    original_get = transpiler._cache.get
+    original_set = transpiler._cache.set
+
+    def timed_get(*args, **kwargs):
+        with recorder.time_call("cache_lookup"):
+            return original_get(*args, **kwargs)
+
+    def timed_set(*args, **kwargs):
+        with recorder.time_call("cache_set"):
+            return original_set(*args, **kwargs)
+
+    transpiler._cache.get = timed_get
+    transpiler._cache.set = timed_set
+
+
+def _measure_sqlglot_and_postprocess(
+    transpiler: SQLTranspiler,
+    statements: List[str],
+    source: str,
+    target: str,
+    recorder: StageRecorder,
+) -> float:
+    """Measure the normal synchronous pipeline with SQLGlot/post-process hooks."""
+    original_transpile = sqlglot.transpile
+    original_process = transpiler.post_processor.process
+
+    def timed_transpile(*args, **kwargs):
+        with recorder.time_call("sqlglot_transpile"):
+            return original_transpile(*args, **kwargs)
+
+    def timed_process(*args, **kwargs):
+        with recorder.time_call("post_process"):
+            return original_process(*args, **kwargs)
+
+    with patch("backend.core.transpiler.sqlglot.transpile", timed_transpile):
+        transpiler.post_processor.process = timed_process
+        return measure_sync(transpiler, statements, source, target)
+
+
+def measure_input_validation(repeats: int) -> Dict[str, float]:
+    """Measure the public type-validation fast path without changing behavior."""
+    timings: List[float] = []
+    transpiler = SQLTranspiler()
+    for _ in range(repeats):
+        start = time.perf_counter()
+        for value in INVALID_INPUTS:
+            transpiler.transpile(value, "mysql", "postgres", pretty=False)
+        timings.append(time.perf_counter() - start)
+    return {
+        "mean_seconds": mean(timings),
+        "median_seconds": median(timings),
+        "timings_seconds": timings,
+        "cases_per_measurement": len(INVALID_INPUTS),
+    }
+
+
+def profile_configuration(
+    statements: List[str],
+    source: str,
+    target: str,
+    pretty: bool,
+    validate: bool,
+    cache_enabled: bool,
+    security_enabled: bool,
+    repeats: int,
+) -> Dict[str, object]:
+    """Profile one stable cache/security/validation configuration."""
+    previous_security = settings.security_check_enabled
+    try:
+        settings.security_check_enabled = security_enabled
+        timings: List[float] = []
+        aggregate = StageRecorder()
+
+        for _ in range(repeats):
+            transpiler = SQLTranspiler()
+            transpiler._cache_enabled = cache_enabled
+            _instrument_transpiler(transpiler, aggregate)
+            elapsed = _measure_sqlglot_and_postprocess(
+                transpiler, statements, source, target, aggregate
+            )
+            timings.append(elapsed)
+
+        total_mean = mean(timings)
+        stage_timings = aggregate.totals
+        per_statement = {name: value / len(statements) / repeats for name, value in stage_timings.items()}
+        known_stage_total = sum(per_statement.values())
+        residual = max(total_mean / len(statements) - known_stage_total, 0.0)
+        per_statement["orchestration_and_inline_validation"] = residual
+        percentages = {
+            name: (value / (total_mean / len(statements)) * 100.0) if total_mean else 0.0
+            for name, value in per_statement.items()
+        }
+
+        return {
+            "cache_enabled": cache_enabled,
+            "security_enabled": security_enabled,
+            "validate": validate,
+            "pretty": pretty,
+            "timings_seconds": timings,
+            "mean_seconds": total_mean,
+            "median_seconds": median(timings),
+            "per_statement_seconds": per_statement,
+            "stage_percent_of_mean": percentages,
+            "stage_calls": aggregate.calls,
+        }
+    finally:
+        settings.security_check_enabled = previous_security
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--iterations", type=int, default=100, help="Statements per measurement")
@@ -79,18 +254,18 @@ def main() -> None:
         parser.error("iterations, repeats, and concurrency must all be >= 1")
 
     statements = build_statements(args.iterations)
-    transpiler = SQLTranspiler()
-    # Benchmark CPU/transpilation work rather than cache retrieval latency.
-    transpiler._cache_enabled = False
 
+    # Preserve the historical wall-clock benchmark: cache-disabled sync/async.
+    baseline_transpiler = SQLTranspiler()
+    baseline_transpiler._cache_enabled = False
     sync_timings = measure_repeated(
-        lambda: measure_sync(transpiler, statements, args.source, args.target),
+        lambda: measure_sync(baseline_transpiler, statements, args.source, args.target),
         args.repeats,
     )
     async_timings = measure_repeated(
         lambda: asyncio.run(
             measure_async(
-                transpiler,
+                baseline_transpiler,
                 statements,
                 args.source,
                 args.target,
@@ -104,13 +279,36 @@ def main() -> None:
     async_mean = mean(async_timings)
     speedup = sync_mean / async_mean if async_mean > 0 else None
 
+    configurations = []
+    for cache_enabled in (False, True):
+        for security_enabled in (False, True):
+            for validate in (False, True):
+                configurations.append(
+                    profile_configuration(
+                        statements,
+                        args.source,
+                        args.target,
+                        pretty=False,
+                        validate=validate,
+                        cache_enabled=cache_enabled,
+                        security_enabled=security_enabled,
+                        repeats=args.repeats,
+                    )
+                )
+
     print(json.dumps({
+        "environment": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "sqlglot": sqlglot.__version__,
+        },
         "workload": {
             "iterations": args.iterations,
             "repeats": args.repeats,
             "source": args.source,
             "target": args.target,
         },
+        "input_validation": measure_input_validation(args.repeats),
         "async": {
             "max_concurrent": args.concurrency,
             "timings_seconds": async_timings,
@@ -121,6 +319,15 @@ def main() -> None:
             "mean_seconds": sync_mean,
         },
         "async_speedup": speedup,
+        "profiling": {
+            "configurations": configurations,
+            "notes": [
+                "Stage timings are benchmark-process instrumentation, not production telemetry.",
+                "orchestration_and_inline_validation is residual wall time after instrumented stage calls.",
+                "validate is a function argument rather than an application settings switch.",
+                "Cache-enabled measurements use a new transpiler per repeat, so each run starts cold.",
+            ],
+        },
     }, ensure_ascii=False, indent=2))
 
 

--- a/backend/benchmarks/transpiler_benchmark.py
+++ b/backend/benchmarks/transpiler_benchmark.py
@@ -69,11 +69,12 @@ def measure_sync(
     statements: List[str],
     source: str,
     target: str,
+    validate: bool = True,
 ) -> float:
     """Measure sequential transpilation wall-clock time."""
     start = time.perf_counter()
     for statement in statements:
-        transpiler.transpile(statement, source, target, pretty=False)
+        transpiler.transpile(statement, source, target, pretty=False, validate=validate)
     return time.perf_counter() - start
 
 
@@ -152,11 +153,13 @@ def _measure_sqlglot_and_postprocess(
     statements: List[str],
     source: str,
     target: str,
+    validate: bool,
     recorder: StageRecorder,
 ) -> float:
     """Measure the normal synchronous pipeline with SQLGlot/post-process hooks."""
     original_transpile = sqlglot.transpile
     original_process = transpiler.post_processor.process
+    original_mask = __import__("backend.core.transpiler", fromlist=["mask_non_executable"]).mask_non_executable
 
     def timed_transpile(*args, **kwargs):
         with recorder.time_call("sqlglot_transpile"):
@@ -166,9 +169,15 @@ def _measure_sqlglot_and_postprocess(
         with recorder.time_call("post_process"):
             return original_process(*args, **kwargs)
 
-    with patch("backend.core.transpiler.sqlglot.transpile", timed_transpile):
+    def timed_mask(*args, **kwargs):
+        with recorder.time_call("security_masking"):
+            return original_mask(*args, **kwargs)
+
+    with patch("backend.core.transpiler.sqlglot.transpile", timed_transpile), patch(
+        "backend.core.transpiler.mask_non_executable", timed_mask
+    ):
         transpiler.post_processor.process = timed_process
-        return measure_sync(transpiler, statements, source, target)
+        return measure_sync(transpiler, statements, source, target, validate=validate)
 
 
 def measure_input_validation(repeats: int) -> Dict[str, float]:
@@ -210,20 +219,27 @@ def profile_configuration(
             transpiler._cache_enabled = cache_enabled
             _instrument_transpiler(transpiler, aggregate)
             elapsed = _measure_sqlglot_and_postprocess(
-                transpiler, statements, source, target, aggregate
+                transpiler, statements, source, target, validate, aggregate
             )
             timings.append(elapsed)
 
         total_mean = mean(timings)
         stage_timings = aggregate.totals
-        per_statement = {name: value / len(statements) / repeats for name, value in stage_timings.items()}
+        per_statement = {
+            name: value / len(statements) / repeats for name, value in stage_timings.items()
+        }
         known_stage_total = sum(per_statement.values())
         residual = max(total_mean / len(statements) - known_stage_total, 0.0)
         per_statement["orchestration_and_inline_validation"] = residual
         percentages = {
-            name: (value / (total_mean / len(statements)) * 100.0) if total_mean else 0.0
+            name: (value / (total_mean / len(statements)) * 100.0)
+            if total_mean
+            else 0.0
             for name, value in per_statement.items()
         }
+        hotspots = sorted(
+            percentages.items(), key=lambda item: item[1], reverse=True
+        )[:2]
 
         return {
             "cache_enabled": cache_enabled,
@@ -236,6 +252,10 @@ def profile_configuration(
             "per_statement_seconds": per_statement,
             "stage_percent_of_mean": percentages,
             "stage_calls": aggregate.calls,
+            "top_hotspots": [
+                {"stage": name, "percent_of_mean": percent}
+                for name, percent in hotspots
+            ],
         }
     finally:
         settings.security_check_enabled = previous_security
@@ -326,6 +346,7 @@ def main() -> None:
                 "orchestration_and_inline_validation is residual wall time after instrumented stage calls.",
                 "validate is a function argument rather than an application settings switch.",
                 "Cache-enabled measurements use a new transpiler per repeat, so each run starts cold.",
+                "top_hotspots ranks the two largest measured contributors for each configuration.",
             ],
         },
     }, ensure_ascii=False, indent=2))


### PR DESCRIPTION
## 背景

Phase 9 已完成低风险重复工作消除：
- #118：复用 `sqlglot.parse()` 结果于 security / multi-statement validation
- #119：cache miss 路径复用 `_cache_key()` 结果
- #120：security-enabled 路径复用 masked SQL

在继续做生产性能优化前，需要先用数据确认真正的热点，避免无证据地引入 async 并发、缓存策略或更大范围重构。

## 目标

建立可重复的 transpiler profiling / benchmark，量化 `SQLTranspiler.transpile()` 关键阶段的耗时占比，并比较不同开关组合。

建议至少覆盖：
1. input validation
2. security masking
3. security checks / multi-statement validation
4. cache lookup
5. `sqlglot.transpile`
6. post_process
7. output validation
8. cache set

## 基准维度

至少比较：
- cache enabled / disabled
- security enabled / disabled
- validation enabled / disabled（若当前配置存在该开关）
- sync path；async 仅用于对照，不据此直接设计并发重构

固定一组代表性 SQL，并保留当前 benchmark 的 warm-up / repeat 方法，确保结果可横向比较。

## 约束

- 本任务以测量为主，不改变生产语义或错误码契约。
- 不为了让 benchmark 变快而修改测试、关闭安全检查或降低验证强度。
- 输出 benchmark JSON artifact，记录环境、配置、样本规模、均值/分位数及阶段占比。
- 对明显异常结果重复运行确认，避免把单次抖动当成性能结论。

## 验收标准

- [ ] 有稳定、可重复的 profiling / benchmark 命令或测试入口。
- [ ] 至少覆盖上述 cache/security/validation 组合。
- [ ] 生成结构化 JSON 结果并可作为 Actions artifact 保留。
- [ ] 报告各阶段耗时及占比，并明确指出下一步最值得优化的 1–2 个热点。
- [ ] 没有生产行为变化；全量测试、quality、CodeQL、benchmark 等现有门禁保持通过。

## 后续决策

仅在 profiling 明确显示热点后，才进入下一张 production perf issue；若 async 与 sync 差异仍不足以证明并发收益，则保持现状，不做无依据的 concurrency redesign。