### PR TITLE
perf: profile statement validation hot path

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,6 +37,13 @@ jobs:
             --concurrency 8 \
             > benchmark.json
 
+      - name: Run statement validation profiler
+        run: |
+          python backend/benchmarks/statement_validation_profile.py \
+            --iterations 100 \
+            --repeats 5 \
+            > statement-validation-profile.json
+
       - name: Publish benchmark summary
         run: |
           python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
@@ -44,6 +51,7 @@ jobs:
           from pathlib import Path
 
           payload = json.loads(Path("benchmark.json").read_text(encoding="utf-8"))
+          profile = json.loads(Path("statement-validation-profile.json").read_text(encoding="utf-8"))
           sync = payload["sync"]["mean_seconds"]
           async_mean = payload["async"]["mean_seconds"]
           speedup = payload["async_speedup"]
@@ -71,6 +79,26 @@ jobs:
                   for item in config["top_hotspots"]
               )
               print(f"- `{label}`: {hotspots}")
+
+          print()
+          print("### Statement validation breakdown")
+          measurements = profile["measurements"]
+          print(
+              f"- `_has_multiple_statements`: "
+              f"`{measurements['has_multiple_statements']['per_statement_ms']:.4f} ms/statement`"
+          )
+          print(
+              f"- `sqlglot.parse()`: "
+              f"`{measurements['sqlglot_parse_only']['per_statement_ms']:.4f} ms/statement`"
+          )
+          print(
+              f"- `parse() + count`: "
+              f"`{measurements['sqlglot_parse_and_count']['per_statement_ms']:.4f} ms/statement`"
+          )
+          print(
+              f"- Parse share of validation: "
+              f"`{profile['analysis']['parse_share_of_statement_validation_percent']:.1f}%`"
+          )
           print()
           print("Benchmark is informational in CI; it does not enforce a fixed latency threshold.")
           PY
@@ -79,6 +107,8 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: transpiler-benchmark-${{ github.sha }}
-          path: benchmark.json
+          path: |
+            benchmark.json
+            statement-validation-profile.json
           if-no-files-found: error
           retention-days: 14

--- a/backend/benchmarks/statement_validation_profile.py
+++ b/backend/benchmarks/statement_validation_profile.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Profile the statement-validation cost without changing production code."""
+
+import argparse
+import json
+import platform
+import time
+from statistics import mean, median
+from typing import Callable, List
+
+import sqlglot
+
+from backend.benchmarks.transpiler_benchmark import build_statements
+from backend.core.transpiler import SQLTranspiler
+
+
+def measure(capture: Callable[[], object], repeats: int) -> List[float]:
+    timings = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        capture()
+        timings.append(time.perf_counter() - start)
+    return timings
+
+
+def run(iterations: int, repeats: int, dialect: str) -> dict:
+    statements = build_statements(iterations)
+    transpiler = SQLTranspiler()
+
+    def validate_only() -> None:
+        for statement in statements:
+            transpiler._has_multiple_statements(statement)
+
+    def parse_only() -> None:
+        for statement in statements:
+            sqlglot.parse(statement)
+
+    def parse_and_count() -> None:
+        for statement in statements:
+            len(sqlglot.parse(statement)) > 1
+
+    validation = measure(validate_only, repeats)
+    parsing = measure(parse_only, repeats)
+    parse_count = measure(parse_and_count, repeats)
+
+    validation_mean = mean(validation)
+    parsing_mean = mean(parsing)
+    parse_count_mean = mean(parse_count)
+    per_statement = iterations
+
+    return {
+        "environment": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "sqlglot": getattr(sqlglot, "__version__", "unknown"),
+        },
+        "workload": {
+            "iterations": iterations,
+            "repeats": repeats,
+            "dialect": dialect,
+        },
+        "measurements": {
+            "has_multiple_statements": {
+                "mean_seconds": validation_mean,
+                "median_seconds": median(validation),
+                "per_statement_ms": validation_mean / per_statement * 1000,
+                "timings_seconds": validation,
+            },
+            "sqlglot_parse_only": {
+                "mean_seconds": parsing_mean,
+                "median_seconds": median(parsing),
+                "per_statement_ms": parsing_mean / per_statement * 1000,
+                "timings_seconds": parsing,
+            },
+            "sqlglot_parse_and_count": {
+                "mean_seconds": parse_count_mean,
+                "median_seconds": median(parse_count),
+                "per_statement_ms": parse_count_mean / per_statement * 1000,
+                "timings_seconds": parse_count,
+            },
+        },
+        "analysis": {
+            "parse_share_of_statement_validation_percent": (
+                parsing_mean / validation_mean * 100.0 if validation_mean else 0.0
+            ),
+            "parse_and_count_share_percent": (
+                parse_count_mean / validation_mean * 100.0 if validation_mean else 0.0
+            ),
+            "validation_over_parse_ms": (
+                (validation_mean - parsing_mean) / per_statement * 1000
+            ),
+            "validation_over_parse_and_count_ms": (
+                (validation_mean - parse_count_mean) / per_statement * 1000
+            ),
+        },
+        "notes": [
+            "This profiler instruments only benchmark-process functions; production code is unchanged.",
+            "_has_multiple_statements currently delegates to sqlglot.parse() and checks the parsed statement count.",
+            "Measurements use the same stable workload family as the main transpiler benchmark.",
+        ],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=100)
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--dialect", default="mysql")
+    args = parser.parse_args()
+    if args.iterations < 1 or args.repeats < 1:
+        parser.error("iterations and repeats must be >= 1")
+    print(json.dumps(run(args.iterations, args.repeats, args.dialect), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/benchmarks/statement_validation_profile_test.py
+++ b/backend/benchmarks/statement_validation_profile_test.py
@@ -5,8 +5,14 @@ def test_statement_validation_profile_reports_parse_breakdown():
     payload = run(iterations=4, repeats=1, dialect="mysql")
     measurements = payload["measurements"]
 
-    assert payload["workload"]["iterations"] == 4
-    assert measurements["has_multiple_statements"]["per_statement_ms"] >= 0
-    assert measurements["sqlglot_parse_only"]["per_statement_ms"] >= 0
-    assert measurements["sqlglot_parse_and_count"]["per_statement_ms"] >= 0
-    assert 0 <= payload["analysis"]["parse_share_of_statement_validation_percent"] < 1000
+    if payload["workload"]["iterations"] != 4:
+        raise AssertionError("unexpected workload iteration count")
+    if measurements["has_multiple_statements"]["per_statement_ms"] < 0:
+        raise AssertionError("negative has_multiple_statements timing")
+    if measurements["sqlglot_parse_only"]["per_statement_ms"] < 0:
+        raise AssertionError("negative parse-only timing")
+    if measurements["sqlglot_parse_and_count"]["per_statement_ms"] < 0:
+        raise AssertionError("negative parse-and-count timing")
+    parse_share = payload["analysis"]["parse_share_of_statement_validation_percent"]
+    if not 0 <= parse_share < 1000:
+        raise AssertionError("invalid parse share")

--- a/backend/benchmarks/statement_validation_profile_test.py
+++ b/backend/benchmarks/statement_validation_profile_test.py
@@ -1,0 +1,12 @@
+from backend.benchmarks.statement_validation_profile import run
+
+
+def test_statement_validation_profile_reports_parse_breakdown():
+    payload = run(iterations=4, repeats=1, dialect="mysql")
+    measurements = payload["measurements"]
+
+    assert payload["workload"]["iterations"] == 4
+    assert measurements["has_multiple_statements"]["per_statement_ms"] >= 0
+    assert measurements["sqlglot_parse_only"]["per_statement_ms"] >= 0
+    assert measurements["sqlglot_parse_and_count"]["per_statement_ms"] >= 0
+    assert 0 <= payload["analysis"]["parse_share_of_statement_validation_percent"] < 1000


### PR DESCRIPTION
Closes #124

Profiling-only slice for the Phase 9 statement-validation hotspot.

Changes:
- add a benchmark-process profiler comparing `_has_multiple_statements()` with direct `sqlglot.parse()` and parse+count;
- run the profiler in the existing Benchmark workflow and publish its breakdown to the job summary;
- add a small regression test for the profiler output shape.

No production implementation is changed. The goal is to quantify whether AST parsing dominates statement validation before considering any optimization.

Acceptance focus:
- preserve the existing sync/async benchmark;
- produce reproducible component-level measurements;
- keep the optimization decision evidence-driven rather than replacing structural parsing with heuristics.