### PR TITLE
perf: move cache lookup before repeated statement validation

### DIFF
--- a/backend/core/transpiler.py
+++ b/backend/core/transpiler.py
@@ -144,18 +144,6 @@ class SQLTranspiler:
                     warnings=security_warnings
                 )
 
-        if multiple_statements is None:
-            multiple_statements = self._has_multiple_statements(sql)
-        if multiple_statements:
-            return TranspileResult(
-                success=False,
-                source_sql=sql,
-                source_dialect=source,
-                target_dialect=target,
-                error="Multiple SQL statements are not supported; submit one statement per request",
-                error_code=ErrorCode.VALIDATION_FAILED.value,
-            )
-
         if source not in SUPPORTED_DIALECTS:
             return TranspileResult(
                 success=False, source_sql=sql, source_dialect=source, target_dialect=target,
@@ -182,6 +170,18 @@ class SQLTranspiler:
             if cached:
                 logger.info("Returning cached result")
                 return TranspileResult(**cached)
+
+        if multiple_statements is None:
+            multiple_statements = self._has_multiple_statements(sql)
+        if multiple_statements:
+            return TranspileResult(
+                success=False,
+                source_sql=sql,
+                source_dialect=source,
+                target_dialect=target,
+                error="Multiple SQL statements are not supported; submit one statement per request",
+                error_code=ErrorCode.VALIDATION_FAILED.value,
+            )
 
         try:
             transpiled = sqlglot.transpile(sql, read=source, write=target, pretty=pretty)[0]

--- a/backend/tests/test_transpiler_cache_order.py
+++ b/backend/tests/test_transpiler_cache_order.py
@@ -1,0 +1,42 @@
+from backend.core.config import settings
+from backend.core.transpiler import SQLTranspiler
+
+
+def test_cache_hit_does_not_repeat_statement_validation(monkeypatch):
+    monkeypatch.setattr(settings, "security_check_enabled", False)
+    transpiler = SQLTranspiler()
+    transpiler._cache_enabled = True
+
+    calls = 0
+    original_has_multiple = transpiler._has_multiple_statements
+
+    def counted_has_multiple(sql):
+        nonlocal calls
+        calls += 1
+        return original_has_multiple(sql)
+
+    monkeypatch.setattr(transpiler, "_has_multiple_statements", counted_has_multiple)
+
+    first = transpiler.transpile("SELECT 1", "mysql", "postgres", validate=False)
+    second = transpiler.transpile("SELECT 1", "mysql", "postgres", validate=False)
+
+    assert first.success is True
+    assert second.success is True
+    assert first.target_sql == second.target_sql
+    assert calls == 1
+
+
+def test_multistatement_sql_remains_rejected_with_cache_enabled(monkeypatch):
+    monkeypatch.setattr(settings, "security_check_enabled", False)
+    transpiler = SQLTranspiler()
+    transpiler._cache_enabled = True
+
+    first = transpiler.transpile("SELECT 1; SELECT 2", "mysql", "postgres", validate=False)
+    second = transpiler.transpile("SELECT 1; SELECT 2", "mysql", "postgres", validate=False)
+
+    assert first.success is False
+    assert second.success is False
+    assert first.error_code == "VALIDATION_FAILED"
+    assert second.error_code == "VALIDATION_FAILED"
+    assert first.target_sql is None
+    assert second.target_sql is None


### PR DESCRIPTION
## Summary
- add a regression test requiring successful cache hits to skip repeated statement validation
- preserve multi-statement rejection with caching enabled
- follow up on the Phase 9 profiling evidence from #128

## Validation
The first commit is intentionally a failing regression test against `main`; implementation will follow after the failure is observed.

Closes #129