### PR TITLE
perf: make cache-key rule snapshot mutation-safe

### DIFF
--- a/backend/core/transpiler.py
+++ b/backend/core/transpiler.py
@@ -69,6 +69,8 @@ class SQLTranspiler:
         self._cache_enabled = settings.cache_enabled
         self._cache = TTLCache(max_size=settings.cache_max_size, ttl=settings.cache_ttl)
         self._security_enabled = settings.security_check_enabled
+        self._rule_cache_snapshot_signature = None
+        self._rule_cache_snapshot_version = None
 
     def transpile(
         self,
@@ -237,15 +239,46 @@ class SQLTranspiler:
         except Exception:
             return False
 
-    def _cache_key(self, sql: str, source: str, target: str, pretty: bool, validate: bool = True,) -> str:
-        rule_payload = "\n".join(
+    def _rule_cache_state(self):
+        """Return a mutation-sensitive structural signature for the current rules."""
+        return tuple(
+            (
+                rule.name,
+                rule.source,
+                rule.target,
+                rule.pattern,
+                rule.replacement,
+                rule.note,
+                rule.category.value,
+                rule.priority,
+                rule.enabled,
+            )
+            for rule in self.post_processor.engine.rules
+        )
+
+    def _build_rule_cache_payload(self) -> str:
+        """Build the canonical rule payload used by the existing cache identity."""
+        return "\n".join(
             "|".join([
                 rule.name, rule.source, rule.target, rule.pattern, rule.replacement,
                 rule.note, rule.category.value, str(rule.priority), str(rule.enabled),
             ])
             for rule in self.post_processor.engine.rules
         )
-        rule_version = hashlib.sha256(rule_payload.encode("utf-8")).hexdigest()[:16]
+
+    def _rule_cache_version(self) -> str:
+        """Reuse the rule-version hash until the effective rule state changes."""
+        signature = self._rule_cache_state()
+        if signature != self._rule_cache_snapshot_signature:
+            payload = self._build_rule_cache_payload()
+            self._rule_cache_snapshot_signature = signature
+            self._rule_cache_snapshot_version = hashlib.sha256(
+                payload.encode("utf-8")
+            ).hexdigest()[:16]
+        return self._rule_cache_snapshot_version
+
+    def _cache_key(self, sql: str, source: str, target: str, pretty: bool, validate: bool = True,) -> str:
+        rule_version = self._rule_cache_version()
         security_version = f"{settings.security_check_enabled}|{settings.security_block_dangerous}"
         return f"v4|{rule_version}|{security_version}|{sql}|{source}|{target}|{pretty}|{validate}"
 

--- a/backend/tests/test_transpiler_rule_snapshot.py
+++ b/backend/tests/test_transpiler_rule_snapshot.py
@@ -1,0 +1,103 @@
+from backend.core.rules import RuleEngine, TransformRule
+from backend.core.post_processor import PostProcessor
+from backend.core.transpiler import SQLTranspiler
+
+
+def _make_rule(name="ifnull_rule"):
+    return TransformRule(
+        name=name,
+        source="mysql",
+        target="postgres",
+        pattern=r"IFNULL\(([^,]+),\s*([^)]+)\)",
+        replacement=r"COALESCE(\1, \2)",
+        note="test rule",
+    )
+
+
+def _make_transpiler(engine=None):
+    transpiler = SQLTranspiler()
+    if engine is not None:
+        transpiler.post_processor = PostProcessor(engine=engine)
+    return transpiler
+
+
+def test_unchanged_rules_reuse_rule_version_hash(monkeypatch):
+    transpiler = _make_transpiler(RuleEngine([_make_rule()]))
+    calls = 0
+    import backend.core.transpiler as transpiler_module
+
+    original_sha256 = transpiler_module.hashlib.sha256
+
+    def counting_sha256(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_sha256(*args, **kwargs)
+
+    monkeypatch.setattr(transpiler_module.hashlib, "sha256", counting_sha256)
+
+    first = transpiler._cache_key("SELECT 1", "mysql", "postgres", False, True)
+    second = transpiler._cache_key("SELECT 1", "mysql", "postgres", False, True)
+
+    assert first == second
+    assert calls == 1
+
+
+def test_direct_rule_mutation_invalidates_cached_rule_version(monkeypatch):
+    rule = _make_rule()
+    transpiler = _make_transpiler(RuleEngine([rule]))
+    calls = 0
+    import backend.core.transpiler as transpiler_module
+
+    original_sha256 = transpiler_module.hashlib.sha256
+
+    def counting_sha256(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_sha256(*args, **kwargs)
+
+    monkeypatch.setattr(transpiler_module.hashlib, "sha256", counting_sha256)
+
+    first = transpiler._cache_key("SELECT 1", "mysql", "postgres", False, True)
+    rule.priority += 1
+    second = transpiler._cache_key("SELECT 1", "mysql", "postgres", False, True)
+
+    assert first != second
+    assert calls == 2
+
+
+def test_direct_engine_rules_list_mutation_invalidates_cached_rule_version(monkeypatch):
+    engine = RuleEngine([_make_rule("rule_a")])
+    transpiler = _make_transpiler(engine)
+    calls = 0
+    import backend.core.transpiler as transpiler_module
+
+    original_sha256 = transpiler_module.hashlib.sha256
+
+    def counting_sha256(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_sha256(*args, **kwargs)
+
+    monkeypatch.setattr(transpiler_module.hashlib, "sha256", counting_sha256)
+
+    transpiler._cache_key("SELECT 1", "mysql", "postgres", False, True)
+    engine.rules.append(_make_rule("rule_b"))
+    transpiler._cache_key("SELECT 1", "mysql", "postgres", False, True)
+
+    assert calls == 2
+
+
+def test_custom_post_processors_have_independent_rule_snapshots(monkeypatch):
+    first_engine = RuleEngine([_make_rule("rule_a")])
+    second_engine = RuleEngine([_make_rule("rule_b")])
+    first = _make_transpiler(first_engine)
+    second = _make_transpiler(second_engine)
+
+    first_key = first._cache_key("SELECT 1", "mysql", "postgres", False, True)
+    second_key = second._cache_key("SELECT 1", "mysql", "postgres", False, True)
+
+    assert first_key != second_key
+
+    first_engine.rules[0].enabled = False
+    assert first._cache_key("SELECT 1", "mysql", "postgres", False, True) != first_key
+    assert second._cache_key("SELECT 1", "mysql", "postgres", False, True) == second_key


### PR DESCRIPTION
Closes #135

## Cache-key rule snapshot optimization

Makes the transpiler's rule-version identity mutation-safe while avoiding repeated payload serialization and SHA-256 hashing when the effective rule state is unchanged.

Regression coverage locks these contracts:
- unchanged rules reuse one rule-version hash;
- direct rule-field mutation invalidates the snapshot;
- direct `engine.rules` mutation invalidates it;
- custom `PostProcessor` engines remain isolated.

Implementation keeps the existing `v4` cache-key shape and derives the snapshot from the effective rule fields and rule order.