### PR TITLE
perf: profile security validation sub-hotspots

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,6 +50,13 @@ jobs:
             --repeats 1000 \
             > cache-key-profile.json
 
+      - name: Run security validation profiler
+        run: |
+          python backend/benchmarks/security_validation_profile.py \
+            --iterations 100 \
+            --repeats 5 \
+            > security-validation-profile.json
+
       - name: Publish benchmark summary
         run: |
           python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
@@ -59,6 +66,7 @@ jobs:
           payload = json.loads(Path("benchmark.json").read_text(encoding="utf-8"))
           profile = json.loads(Path("statement-validation-profile.json").read_text(encoding="utf-8"))
           cache_profile = json.loads(Path("cache-key-profile.json").read_text(encoding="utf-8"))
+          security_profile = json.loads(Path("security-validation-profile.json").read_text(encoding="utf-8"))
           sync = payload["sync"]["mean_seconds"]
           async_mean = payload["async"]["mean_seconds"]
           speedup = payload["async_speedup"]
@@ -129,6 +137,28 @@ jobs:
               f"- Rules: `{cache_profile['workload']['rule_count']}`, "
               f"payload: `{cache_profile['workload']['rule_payload_bytes']} bytes`"
           )
+
+          print()
+          print("### Security validation breakdown")
+          security_measurements = security_profile["measurements"]
+          security_shares = security_profile["analysis"]["substage_share_of_full_validation_percent"]
+          for stage in (
+              "mask_non_executable",
+              "dangerous_operation_regex",
+              "sqlglot_parse",
+              "dangerous_pattern_scan",
+              "warning_pattern_scan",
+          ):
+              measurement = security_measurements[stage]
+              print(
+                  f"- `{stage}`: `{measurement['per_statement_ms']:.4f} ms/statement` "
+                  f"({security_shares[stage]:.1f}% of full validation)"
+              )
+          print(
+              f"- `_validate_security()`: "
+              f"`{security_measurements['validate_security']['per_statement_ms']:.4f} ms/statement`"
+          )
+
           print()
           print("Benchmark is informational in CI; it does not enforce a fixed latency threshold.")
           PY
@@ -141,5 +171,6 @@ jobs:
             benchmark.json
             statement-validation-profile.json
             cache-key-profile.json
+            security-validation-profile.json
           if-no-files-found: error
           retention-days: 14

--- a/backend/benchmarks/security_validation_profile.py
+++ b/backend/benchmarks/security_validation_profile.py
@@ -4,26 +4,24 @@
 import argparse
 import json
 import platform
-import re
 import time
 from statistics import mean, median
 from typing import Callable, Dict, List
-from unittest.mock import patch
 
 import sqlglot
 
 from backend.benchmarks.transpiler_benchmark import DEFAULT_STATEMENTS
 from backend.core import transpiler as transpiler_module
-from backend.core.config import DANGEROUS_SQL_PATTERNS, WARNING_SQL_PATTERNS, settings
+from backend.core.config import DANGEROUS_SQL_PATTERNS, WARNING_SQL_PATTERNS
 from backend.core.transpiler import SQLTranspiler, _DANGEROUS_OPERATION_PATTERN
 
 
-EXECUTABLE_STATEMENTS = [statement for statement in DEFAULT_STATEMENTS if statement]
 SECURITY_CASES = [
     ("select", "SELECT id, name FROM users WHERE id > 100"),
     ("dangerous_operation", "DROP TABLE users"),
     ("dml_warning", "UPDATE users SET name = 'x'"),
     ("literal_keyword", "SELECT 'DROP TABLE users' AS text"),
+    ("comment_keyword", "SELECT 1 -- DROP TABLE users"),
 ]
 
 
@@ -44,7 +42,6 @@ def _pattern_scan(sql: str, patterns) -> None:
 def run(iterations: int, repeats: int) -> Dict[str, object]:
     statements = [DEFAULT_STATEMENTS[index % len(DEFAULT_STATEMENTS)] for index in range(iterations)]
     transpiler = SQLTranspiler()
-
     original_mask = transpiler_module.mask_non_executable
     masked = [original_mask(statement) for statement in statements]
 
@@ -92,6 +89,19 @@ def run(iterations: int, repeats: int) -> Dict[str, object]:
         if name != "validate_security"
     }
 
+    boundary_cases = []
+    for name, sql in SECURITY_CASES:
+        result = transpiler._validate_security(sql)
+        boundary_cases.append(
+            {
+                "name": name,
+                "sql": sql,
+                "blocked": result["blocked"],
+                "multiple_statements": result.get("multiple_statements", False),
+                "warning_count": len(result.get("warnings", [])),
+            }
+        )
+
     return {
         "environment": {
             "python": platform.python_version(),
@@ -121,20 +131,12 @@ def run(iterations: int, repeats: int) -> Dict[str, object]:
                 "warning_count": len(WARNING_SQL_PATTERNS),
             },
         },
-        "boundary_cases": [
-            {
-                "name": name,
-                "sql": sql,
-                "blocked": transpiler._validate_security(sql)["blocked"],
-                "multiple_statements": transpiler._validate_security(sql).get("multiple_statements"),
-            }
-            for name, sql in SECURITY_CASES
-        ],
+        "boundary_cases": boundary_cases,
         "notes": [
             "This profiler instruments only benchmark-process functions; production code is unchanged.",
             "Substage timings are isolated measurements and are not additive because they use separate runs.",
             "The full validation measurement uses SQLTranspiler._validate_security() with current repository behavior.",
-            "Boundary cases verify executable-vs-non-executable behavior alongside timing data.",
+            "Boundary cases include executable and masked keyword locations and record current blocking/warning behavior.",
         ],
     }
 

--- a/backend/benchmarks/security_validation_profile.py
+++ b/backend/benchmarks/security_validation_profile.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Profile security-validation sub-stages without changing production code."""
+
+import argparse
+import json
+import platform
+import re
+import time
+from statistics import mean, median
+from typing import Callable, Dict, List
+from unittest.mock import patch
+
+import sqlglot
+
+from backend.benchmarks.transpiler_benchmark import DEFAULT_STATEMENTS
+from backend.core import transpiler as transpiler_module
+from backend.core.config import DANGEROUS_SQL_PATTERNS, WARNING_SQL_PATTERNS, settings
+from backend.core.transpiler import SQLTranspiler, _DANGEROUS_OPERATION_PATTERN
+
+
+EXECUTABLE_STATEMENTS = [statement for statement in DEFAULT_STATEMENTS if statement]
+SECURITY_CASES = [
+    ("select", "SELECT id, name FROM users WHERE id > 100"),
+    ("dangerous_operation", "DROP TABLE users"),
+    ("dml_warning", "UPDATE users SET name = 'x'"),
+    ("literal_keyword", "SELECT 'DROP TABLE users' AS text"),
+]
+
+
+def measure(capture: Callable[[], object], repeats: int) -> List[float]:
+    timings = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        capture()
+        timings.append(time.perf_counter() - start)
+    return timings
+
+
+def _pattern_scan(sql: str, patterns) -> None:
+    for pattern, _ in patterns:
+        pattern.search(sql)
+
+
+def run(iterations: int, repeats: int) -> Dict[str, object]:
+    statements = [DEFAULT_STATEMENTS[index % len(DEFAULT_STATEMENTS)] for index in range(iterations)]
+    transpiler = SQLTranspiler()
+
+    original_mask = transpiler_module.mask_non_executable
+    masked = [original_mask(statement) for statement in statements]
+
+    def mask_only() -> None:
+        for statement in statements:
+            original_mask(statement)
+
+    def dangerous_operation_only() -> None:
+        for statement in masked:
+            _DANGEROUS_OPERATION_PATTERN.search(statement)
+
+    def parse_only() -> None:
+        for statement in statements:
+            sqlglot.parse(statement)
+
+    def dangerous_patterns_only() -> None:
+        for statement in masked:
+            _pattern_scan(statement, DANGEROUS_SQL_PATTERNS)
+
+    def warning_patterns_only() -> None:
+        for statement in masked:
+            _pattern_scan(statement, WARNING_SQL_PATTERNS)
+
+    def full_security() -> None:
+        for statement in statements:
+            transpiler._validate_security(statement)
+
+    timings = {
+        "mask_non_executable": measure(mask_only, repeats),
+        "dangerous_operation_regex": measure(dangerous_operation_only, repeats),
+        "sqlglot_parse": measure(parse_only, repeats),
+        "dangerous_pattern_scan": measure(dangerous_patterns_only, repeats),
+        "warning_pattern_scan": measure(warning_patterns_only, repeats),
+        "validate_security": measure(full_security, repeats),
+    }
+
+    means = {name: mean(values) for name, values in timings.items()}
+    per_statement_ms = {
+        name: value / iterations * 1000.0 for name, value in means.items()
+    }
+    full_mean = means["validate_security"]
+    shares = {
+        name: (value / full_mean * 100.0 if full_mean else 0.0)
+        for name, value in means.items()
+        if name != "validate_security"
+    }
+
+    return {
+        "environment": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "sqlglot": getattr(sqlglot, "__version__", "unknown"),
+        },
+        "workload": {
+            "iterations": iterations,
+            "repeats": repeats,
+            "case_count": len(SECURITY_CASES),
+            "statement_family": "existing transpiler benchmark DEFAULT_STATEMENTS",
+        },
+        "measurements": {
+            name: {
+                "mean_seconds": mean(values),
+                "median_seconds": median(values),
+                "per_statement_ms": per_statement_ms[name],
+                "timings_seconds": values,
+            }
+            for name, values in timings.items()
+        },
+        "analysis": {
+            "substage_share_of_full_validation_percent": shares,
+            "full_validation_total_seconds_mean": full_mean,
+            "patterns": {
+                "dangerous_count": len(DANGEROUS_SQL_PATTERNS),
+                "warning_count": len(WARNING_SQL_PATTERNS),
+            },
+        },
+        "boundary_cases": [
+            {
+                "name": name,
+                "sql": sql,
+                "blocked": transpiler._validate_security(sql)["blocked"],
+                "multiple_statements": transpiler._validate_security(sql).get("multiple_statements"),
+            }
+            for name, sql in SECURITY_CASES
+        ],
+        "notes": [
+            "This profiler instruments only benchmark-process functions; production code is unchanged.",
+            "Substage timings are isolated measurements and are not additive because they use separate runs.",
+            "The full validation measurement uses SQLTranspiler._validate_security() with current repository behavior.",
+            "Boundary cases verify executable-vs-non-executable behavior alongside timing data.",
+        ],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=100)
+    parser.add_argument("--repeats", type=int, default=5)
+    args = parser.parse_args()
+    if args.iterations < 1 or args.repeats < 1:
+        parser.error("iterations and repeats must be >= 1")
+    print(json.dumps(run(args.iterations, args.repeats), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_security_validation_profile.py
+++ b/backend/tests/test_security_validation_profile.py
@@ -1,0 +1,44 @@
+from backend.benchmarks.security_validation_profile import SECURITY_CASES, run
+
+
+def test_security_validation_profile_shape():
+    payload = run(iterations=4, repeats=1)
+
+    assert set(payload) == {
+        "environment",
+        "workload",
+        "measurements",
+        "analysis",
+        "boundary_cases",
+        "notes",
+    }
+    assert payload["workload"]["iterations"] == 4
+    assert payload["workload"]["repeats"] == 1
+    assert payload["workload"]["case_count"] == len(SECURITY_CASES)
+
+    expected_stages = {
+        "mask_non_executable",
+        "dangerous_operation_regex",
+        "sqlglot_parse",
+        "dangerous_pattern_scan",
+        "warning_pattern_scan",
+        "validate_security",
+    }
+    assert set(payload["measurements"]) == expected_stages
+    for measurement in payload["measurements"].values():
+        assert measurement["mean_seconds"] >= 0
+        assert measurement["median_seconds"] >= 0
+        assert measurement["per_statement_ms"] >= 0
+        assert len(measurement["timings_seconds"]) == 1
+
+    assert set(payload["analysis"]) == {
+        "substage_share_of_full_validation_percent",
+        "full_validation_total_seconds_mean",
+        "patterns",
+    }
+    assert len(payload["boundary_cases"]) == len(SECURITY_CASES)
+    assert all(
+        {"name", "sql", "blocked", "multiple_statements", "warning_count"}
+        <= set(case)
+        for case in payload["boundary_cases"]
+    )


### PR DESCRIPTION
Closes #143

## Scope
- add a benchmark-process profiler for `_validate_security()` sub-stages;
- measure masking, dangerous-operation regex, `sqlglot.parse()`, dangerous-pattern scans, warning-pattern scans, and end-to-end security validation;
- record executable/non-executable boundary cases in structured JSON;
- add a shape regression test without timing thresholds;
- run the profiler from the existing Benchmark workflow and retain its JSON artifact.

## Scope discipline
No production runtime behavior changes. The profiler is intended to establish evidence for at most one minimal follow-up optimization.

## Validation
The existing five workflow gates remain required.