### PR TITLE
test: lock aggregation RuleEngine structural safety contracts

### DIFF
--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -26,9 +26,13 @@ from .exceptions import (
     ValidationError,
 )
 from .compatibility import install_compatibility_patches
+from .structured_aggregation import install_structured_aggregation_rules
 
 # Legacy compatibility adapters are installed through one explicit, idempotent entry point.
 install_compatibility_patches()
+# Install the scanner-backed aggregation handlers after legacy patches so the
+# structural rewrite contract remains the effective runtime implementation.
+install_structured_aggregation_rules()
 
 __all__ = [
     "setup_logging",

--- a/backend/core/structured_aggregation.py
+++ b/backend/core/structured_aggregation.py
@@ -1,0 +1,229 @@
+"""Scanner-backed structural rewrites for aggregation function rules."""
+from __future__ import annotations
+
+import re
+from typing import Callable
+
+from .function_call_scanner import replace_function_calls
+from .p1_sql_scanner import mask_non_executable
+from .rules import TransformRule
+
+
+def _split_top_level_args(args: str) -> list[str]:
+    masked = mask_non_executable(args)
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    for index, char in enumerate(masked):
+        if char == "(":
+            depth += 1
+        elif char == ")" and depth:
+            depth -= 1
+        elif char == "," and depth == 0:
+            parts.append(args[start:index].strip())
+            start = index + 1
+    parts.append(args[start:].strip())
+    return parts
+
+
+def _top_level_keyword(text: str, keyword: str) -> int:
+    masked = mask_non_executable(text)
+    wanted = keyword.upper()
+    depth = 0
+    for index, char in enumerate(masked):
+        if char == "(":
+            depth += 1
+            continue
+        if char == ")" and depth:
+            depth -= 1
+            continue
+        if depth == 0 and masked[index:index + len(wanted)].upper() == wanted:
+            before = masked[index - 1] if index else " "
+            after_index = index + len(wanted)
+            after = masked[after_index] if after_index < len(masked) else " "
+            if not (before.isalnum() or before == "_") and not (after.isalnum() or after == "_"):
+                return index
+    return -1
+
+
+def _replace_string_agg(args: str, original: str, target: str) -> str:
+    values = _split_top_level_args(args)
+    if len(values) != 2 or not all(values):
+        return original
+    expression, separator = values
+    if target == "mysql":
+        return f"GROUP_CONCAT({expression} SEPARATOR {separator})"
+    return f"STRING_AGG({expression}::TEXT, {separator})"
+
+
+def _replace_group_concat(args: str, original: str) -> str:
+    separator_position = _top_level_keyword(args, "SEPARATOR")
+    before_separator = args if separator_position < 0 else args[:separator_position].rstrip()
+    separator = "','" if separator_position < 0 else args[separator_position + len("SEPARATOR"):].strip()
+    if not separator:
+        return original
+
+    order_position = _top_level_keyword(before_separator, "ORDER BY")
+    expression = before_separator if order_position < 0 else before_separator[:order_position].rstrip()
+    order_by = None if order_position < 0 else before_separator[order_position + len("ORDER BY"):].strip()
+    distinct = bool(re.match(r"^DISTINCT\b", expression, re.IGNORECASE))
+    if distinct:
+        expression = re.sub(r"^DISTINCT\s+", "", expression, count=1, flags=re.IGNORECASE).strip()
+    if not expression:
+        return original
+
+    prefix = "DISTINCT " if distinct else ""
+    result = f"STRING_AGG({prefix}{expression}::TEXT, {separator}"
+    if order_by:
+        result += f" ORDER BY {order_by}"
+    return result + ")"
+
+
+def _replace_listagg(sql: str) -> tuple[str, bool]:
+    function_name = "LISTAGG"
+    masked = mask_non_executable(sql)
+    name_upper = function_name.upper()
+    length = len(sql)
+    result: list[str] = []
+    cursor = 0
+    index = 0
+    applied = False
+
+    while index < length:
+        if masked[index:index + len(function_name)].upper() != name_upper:
+            index += 1
+            continue
+        if index > 0 and (masked[index - 1].isalnum() or masked[index - 1] == "_"):
+            index += 1
+            continue
+
+        open_index = index + len(function_name)
+        while open_index < length and masked[open_index].isspace():
+            open_index += 1
+        if open_index >= length or masked[open_index] != "(":
+            index += 1
+            continue
+
+        depth = 0
+        close_index = open_index
+        while close_index < length:
+            char = masked[close_index]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            close_index += 1
+        if close_index >= length or depth != 0:
+            index += 1
+            continue
+
+        suffix_index = close_index + 1
+        while suffix_index < length and masked[suffix_index].isspace():
+            suffix_index += 1
+        within_group = "WITHIN" + " " + "GROUP"
+        if masked[suffix_index:suffix_index + len(within_group)].upper() != within_group:
+            index += 1
+            continue
+        suffix_index += len(within_group)
+        while suffix_index < length and masked[suffix_index].isspace():
+            suffix_index += 1
+        if suffix_index >= length or masked[suffix_index] != "(":
+            index += 1
+            continue
+
+        order_depth = 0
+        order_close = suffix_index
+        while order_close < length:
+            char = masked[order_close]
+            if char == "(":
+                order_depth += 1
+            elif char == ")":
+                order_depth -= 1
+                if order_depth == 0:
+                    break
+            order_close += 1
+        if order_close >= length or order_depth != 0:
+            index += 1
+            continue
+
+        args = sql[open_index + 1:close_index]
+        order_clause = sql[suffix_index + 1:order_close].strip()
+        if not re.match(r"^ORDER\s+BY\b", order_clause, re.IGNORECASE):
+            index += 1
+            continue
+
+        values = _split_top_level_args(args)
+        if len(values) != 2 or not all(values):
+            index += 1
+            continue
+
+        result.append(sql[cursor:index])
+        result.append(f"ARRAY_JOIN(COLLECT_LIST({values[0]}), {values[1]})")
+        cursor = order_close + 1
+        index = cursor
+        applied = True
+
+    if not applied:
+        return sql, False
+    result.append(sql[cursor:])
+    return "".join(result), True
+
+
+def install_structured_aggregation_rules() -> None:
+    """Install structural aggregation handlers after legacy patches are loaded."""
+    current_apply = TransformRule.apply
+    if getattr(current_apply, "_sdm_structured_aggregation", False):
+        return
+
+    handlers: dict[str, Callable[[TransformRule, str], tuple[str, bool]]] = {}
+
+    def string_agg_mysql(self: TransformRule, sql: str) -> tuple[str, bool]:
+        if not self.enabled:
+            return sql, False
+        applied = False
+
+        def replacer(args: str, original: str) -> str:
+            nonlocal applied
+            transformed = _replace_string_agg(args, original, "mysql")
+            applied = applied or transformed != original
+            return transformed
+
+        return replace_function_calls(sql, "STRING_AGG", replacer), applied
+
+    def string_agg_postgres(self: TransformRule, sql: str) -> tuple[str, bool]:
+        if not self.enabled:
+            return sql, False
+        applied = False
+
+        def replacer(args: str, original: str) -> str:
+            nonlocal applied
+            transformed = _replace_string_agg(args, original, "postgres")
+            applied = applied or transformed != original
+            return transformed
+
+        return replace_function_calls(sql, "GROUP_CONCAT", replacer), applied
+
+    handlers["tsql_string_agg_to_mysql"] = string_agg_mysql
+    handlers["postgres_string_agg_to_mysql"] = string_agg_mysql
+    handlers["mysql_group_concat_to_postgres"] = string_agg_postgres
+
+    def listagg_handler(self: TransformRule, sql: str) -> tuple[str, bool]:
+        if not self.enabled:
+            return sql, False
+        return _replace_listagg(sql)
+
+    handlers["oracle_listagg_to_hive"] = listagg_handler
+
+    def apply(self: TransformRule, sql: str) -> tuple[str, bool]:
+        handler = handlers.get(self.name)
+        if handler is not None:
+            return handler(self, sql)
+        return current_apply(self, sql)
+
+    apply._sdm_structured_aggregation = True  # type: ignore[attr-defined]
+    TransformRule.apply = apply
+
+
+__all__ = ["install_structured_aggregation_rules"]

--- a/backend/core/structured_aggregation.py
+++ b/backend/core/structured_aggregation.py
@@ -192,14 +192,14 @@ def install_structured_aggregation_rules() -> None:
 
         return replace_function_calls(sql, "STRING_AGG", replacer), applied
 
-    def string_agg_postgres(self: TransformRule, sql: str) -> tuple[str, bool]:
+    def group_concat_postgres(self: TransformRule, sql: str) -> tuple[str, bool]:
         if not self.enabled:
             return sql, False
         applied = False
 
         def replacer(args: str, original: str) -> str:
             nonlocal applied
-            transformed = _replace_string_agg(args, original, "postgres")
+            transformed = _replace_group_concat(args, original)
             applied = applied or transformed != original
             return transformed
 
@@ -207,7 +207,7 @@ def install_structured_aggregation_rules() -> None:
 
     handlers["tsql_string_agg_to_mysql"] = string_agg_mysql
     handlers["postgres_string_agg_to_mysql"] = string_agg_mysql
-    handlers["mysql_group_concat_to_postgres"] = string_agg_postgres
+    handlers["mysql_group_concat_to_postgres"] = group_concat_postgres
 
     def listagg_handler(self: TransformRule, sql: str) -> tuple[str, bool]:
         if not self.enabled:

--- a/backend/tests/test_aggregation_rule_structural_safety.py
+++ b/backend/tests/test_aggregation_rule_structural_safety.py
@@ -1,0 +1,84 @@
+import pytest
+
+from backend.core.rules import TRANSFORM_RULES
+
+
+def _rule(name: str):
+    for rule in TRANSFORM_RULES:
+        if rule.name == name:
+            return rule
+    raise AssertionError(f"Missing rule: {name}")
+
+
+@pytest.mark.parametrize(
+    ("rule_name", "sql", "expected"),
+    [
+        (
+            "tsql_string_agg_to_mysql",
+            "SELECT STRING_AGG(CONCAT(first_name, last_name), ',') FROM users",
+            "SELECT GROUP_CONCAT(CONCAT(first_name, last_name) SEPARATOR ',') FROM users",
+        ),
+        (
+            "mysql_group_concat_to_postgres",
+            "SELECT GROUP_CONCAT(CONCAT(first_name, last_name) SEPARATOR ',') FROM users",
+            "SELECT STRING_AGG(CONCAT(first_name, last_name)::TEXT, ',') FROM users",
+        ),
+        (
+            "postgres_string_agg_to_mysql",
+            "SELECT STRING_AGG(CONCAT(first_name, last_name), ',') FROM users",
+            "SELECT GROUP_CONCAT(CONCAT(first_name, last_name) SEPARATOR ',') FROM users",
+        ),
+    ],
+)
+def test_string_aggregation_rules_consume_complete_nested_arguments(rule_name, sql, expected):
+    """Aggregation rewrites must not stop at an inner comma or parenthesis."""
+    transformed, applied = _rule(rule_name).apply(sql)
+
+    assert applied is True
+    assert transformed == expected
+
+
+def test_listagg_rule_accepts_nested_expression_and_order_expression():
+    """LISTAGG must consume the complete value and ORDER BY expressions."""
+    rule = _rule("oracle_listagg_to_hive")
+    sql = (
+        "SELECT LISTAGG(CONCAT(first_name, last_name), ',') "
+        "WITHIN GROUP (ORDER BY LOWER(last_name)) FROM users"
+    )
+
+    transformed, applied = rule.apply(sql)
+
+    assert applied is True
+    assert transformed == "SELECT ARRAY_JOIN(COLLECT_LIST(CONCAT(first_name, last_name)), ',') FROM users"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT 'GROUP_CONCAT(CONCAT(a, b))' FROM users",
+        'SELECT "STRING_AGG(CONCAT(a, b), \',\')" FROM users',
+        "SELECT GROUP_CONCAT(name) -- GROUP_CONCAT(CONCAT(a, b))\nFROM users",
+        "SELECT /* STRING_AGG(CONCAT(a, b), ',') */ STRING_AGG(name, ',') FROM users",
+    ],
+)
+def test_aggregation_rules_do_not_cross_lexical_boundaries(sql):
+    """Function tokens in literals, identifiers, and comments are not SQL calls."""
+    rules = (
+        _rule("mysql_group_concat_to_postgres"),
+        _rule("postgres_string_agg_to_mysql"),
+    )
+
+    for rule in rules:
+        transformed, _ = rule.apply(sql)
+        assert "GROUP_CONCAT(CONCAT(a, b))" in transformed or "STRING_AGG(CONCAT(a, b), ',')" in transformed
+
+
+def test_malformed_aggregation_expression_remains_unchanged():
+    """An incomplete function call must fail closed rather than partially rewrite."""
+    rule = _rule("postgres_string_agg_to_mysql")
+    sql = "SELECT STRING_AGG(CONCAT(first_name, last_name), ',' FROM users"
+
+    transformed, applied = rule.apply(sql)
+
+    assert applied is False
+    assert transformed == sql


### PR DESCRIPTION
Closes #152

## Structural safety hardening
Lock and implement structural rewrite contracts for the aggregation rules that previously relied on regex argument boundaries.

Coverage includes:
- nested STRING_AGG / GROUP_CONCAT arguments
- nested LISTAGG value and ORDER BY expressions
- function tokens inside literals, quoted identifiers, and comments
- malformed/incomplete calls remain unchanged

## Implementation
- Add scanner-backed aggregation handlers using lexical masking and balanced function-call parsing.
- Route `mysql_group_concat_to_postgres` through the dedicated GROUP_CONCAT parser so `SEPARATOR`, `ORDER BY`, and nested expressions are consumed structurally.
- Install the structured handlers after legacy compatibility patches so the hardened implementations are effective without disturbing unrelated legacy rules.

## Verification
All required gates are green on head `9fd69da87ca6ffa9e0af45ccb217ac81f828285c`: CI, Quality, CodeQL, Benchmark, and README Consistency.